### PR TITLE
Improve failed parquet download retries

### DIFF
--- a/tests/test_candle_universe.py
+++ b/tests/test_candle_universe.py
@@ -382,11 +382,11 @@ def test_load_candles_using_jsonl(persistent_test_client: Client):
     candle_universe = GroupedCandleUniverse(candles_df)
 
     first_at, last_at = candle_universe.get_timestamp_range()
-    assert first_at == pd.Timestamp('2021-04-23 23:00:00')
+    assert first_at == pd.Timestamp('2021-04-24 01:00:00')
     assert last_at >= pd.Timestamp('2022-08-10 11:00:00')
 
     test_price = candle_universe.get_closest_price(pair.pair_id, pd.Timestamp("2022-01-01"))
-    assert test_price == pytest.approx(518.1773243974246)
+    assert test_price == pytest.approx(516.9167236844088)
 
 
 def test_load_candles_using_jsonl_max_bytes(persistent_test_client: Client):


### PR DESCRIPTION
Closes https://github.com/tradingstrategy-ai/trade-executor/issues/14

This PR improves the following:
 - If a corrupted parquet file is detected, only that file is purged,
   not the entire cache.
 - We do not sleep unnecessarily after the last failed download attempt
 - When we give up on retrying, we still clean the corrupted file,
   so that any next runs do not hit an unnecessary error on first
   attempt
 - Fixed the retry count logic, we now actually raise the last
   exception during the last attempt instead of silently returning None