### PR TITLE
Never expire cached candle files with end time

### DIFF
--- a/.github/workflows/pip-install.yml
+++ b/.github/workflows/pip-install.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - name: Check pip install from PyPi works

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -14,21 +14,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Install poetry
-      run: pipx install poetry
+      with:
+        submodules: 'recursive'
     - name: Set up Python 3.9
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: 3.9
-        cache: 'poetry'
-    - name: Initialize submodules
-      run: |
-        git submodule update --init --recursive
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+        installer-parallel: true
+    - name: Load cached venv
+      uses: actions/cache@v2
+      with:
+        path: .venv
+        key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
     - name: Install dependencies
-      run: |
-        poetry install -E qstrader
+      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+      run: poetry install --no-interaction -E qstrader
     - name: Run test scripts
-      run: |
-        poetry run pytest --tb=native
+      run: poetry run pytest --tb=native
       env:
         TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}

--- a/tests/transport/test_cache.py
+++ b/tests/transport/test_cache.py
@@ -1,0 +1,199 @@
+import datetime as dt
+import time
+from unittest.mock import Mock
+
+import pytest
+
+from tradingstrategy.timebucket import TimeBucket
+
+
+@pytest.fixture()
+def class_under_test():
+    from tradingstrategy.transport.cache import CachedHTTPTransport
+
+    return CachedHTTPTransport
+
+
+def test_get_cached_item_no_cache_file(class_under_test, tmp_path):
+    transport = class_under_test(download_func=Mock())
+    filename = transport.get_cached_item(tmp_path / "not_here.parquet")
+    assert filename is None
+
+
+def test_get_cached_item_cache_file_with_end_time(class_under_test, tmp_path):
+    transport = class_under_test(download_func=Mock())
+
+    # Cached candle data with end time should never expire, no matter how old they are
+    tmp_file = tmp_path / "candles-jsonl-1m-to_1998-03-31_19-38-02-58000fef3f0a6af9d8393f50d530d3db.parquet"
+    tmp_file.write_text("I am candle data!")  # actually create the file
+
+    transport.cache_period = dt.timedelta(microseconds=1)  # Should NOT affect expiration
+    time.sleep(0.000_002) # Assure that cache period otherwise definitely expires
+    filename = transport.get_cached_item(tmp_file)
+
+    assert filename == tmp_file
+
+
+def test_get_cached_item_cache_file_no_end_time_recent_enough(class_under_test, tmp_path):
+    transport = class_under_test(download_func=Mock())
+
+    # Cached candle data with end time should never expire, no matter how old they are
+    tmp_file = tmp_path / "candles-jsonl-1m-58000fef3f0a6af9d8393f50d530d3db.parquet"
+    tmp_file.write_text("I am candle data!")  # actually create the file
+
+    transport.cache_period = dt.timedelta(days=1)
+    filename = transport.get_cached_item(tmp_file)
+
+    assert filename == tmp_file
+
+
+def test_get_cached_item_cache_file_no_end_time_expired(class_under_test, tmp_path):
+    transport = class_under_test(download_func=Mock())
+
+    # Cached candle data with end time should never expire, no matter how old they are
+    tmp_file = tmp_path / "candles-jsonl-1m-58000fef3f0a6af9d8393f50d530d3db.parquet"
+    tmp_file.write_text("I am candle data!")  # actually create the file
+
+    transport.cache_period = dt.timedelta(microseconds=1)
+    time.sleep(0.000_002)  # Assure cache expires even on the fastest computer in the universe
+    filename = transport.get_cached_item(tmp_file)
+
+    assert filename is None
+
+
+@pytest.mark.parametrize(
+    "kwarg_overrides, expected_name",
+    (
+        (
+            {},  # no overrides
+            "candles-jsonl-1m-b445ce65b8b8117fef6ee7b9b44b98ac.parquet"
+        ),
+        (
+            {"pair_ids": {22, 1717, 88}},
+            "candles-jsonl-1m-3650b4fd16270e6522eddbeffa6fa676.parquet"
+        ),
+        (
+            {"start_time": dt.datetime(2021, 11, 15, 19, 7, 50, 654321)},
+            "candles-jsonl-1m-932cd917d5f82f60c3c1e39c6725a427.parquet"
+        ),
+        (
+            {"max_bytes": 1024 * 1024},
+            "candles-jsonl-1m-58000fef3f0a6af9d8393f50d530d3db.parquet"
+        ),
+    ),
+)
+def test__generate_cache_name_no_end_time(
+    class_under_test, kwarg_overrides, expected_name
+):
+    transport = class_under_test(download_func=Mock())
+
+    kwargs = {
+        "pair_ids": {2, 17, 8},
+        "time_bucket": TimeBucket.m1,
+        "start_time": dt.datetime(2021, 7, 1, 14, 35, 17, 123456),
+        "end_time": None,
+        "max_bytes": 1337,
+    } | kwarg_overrides
+
+    name = transport._generate_cache_name(**kwargs)
+
+    assert name == expected_name
+
+
+@pytest.mark.parametrize(
+    "time_bucket, end_time, expected_name",
+    (
+        # For sub-hour time buckets the seconds part should be truncated from end date.
+        (
+            TimeBucket.m1,
+            dt.datetime(2022, 8, 18, 12, 59, 24, 987654),
+            "candles-jsonl-1m-to_2022-08-18_12-59-00-3d66bc1d7a463e6ddb99fbc57e83b98e.parquet"
+        ),
+        (
+            TimeBucket.m15,
+            dt.datetime(2022, 8, 18, 12, 59, 59, 999999),
+            "candles-jsonl-15m-to_2022-08-18_12-59-00-42b45ce03eb586963e1e660f8bd7cab8.parquet"
+        ),
+    ),
+)
+def test__generate_cache_name_end_time_minute_precision(
+    class_under_test, time_bucket, end_time, expected_name
+):
+    transport = class_under_test(download_func=Mock())
+
+    name = transport._generate_cache_name(
+        pair_ids=[10, 20, 30],
+        end_time=end_time,
+        time_bucket=time_bucket,
+    )
+
+    assert name == expected_name
+
+
+@pytest.mark.parametrize(
+    "time_bucket, end_time, expected_name",
+    (
+        # For sub-day time buckets the minutes and seconds parts should be truncated
+        # from end date.
+        (
+            TimeBucket.h1,
+            dt.datetime(2022, 8, 18, 12, 34, 56, 987654),
+            "candles-jsonl-1h-to_2022-08-18_12-00-00-e0c2fcf28f4b3a68761bcad0ba4e3e0e.parquet"
+        ),
+        (
+            TimeBucket.h4,
+            dt.datetime(2022, 8, 18, 12, 59, 59, 999999),
+            "candles-jsonl-4h-to_2022-08-18_12-00-00-01dc13144bc9902e795b62eff9d17ed2.parquet"
+        ),
+    ),
+)
+def test__generate_cache_name_end_time_hour_precision(
+    class_under_test, time_bucket, end_time, expected_name
+):
+    transport = class_under_test(download_func=Mock())
+
+    name = transport._generate_cache_name(
+        pair_ids=[10, 20, 30],
+        end_time=end_time,
+        time_bucket=time_bucket,
+    )
+
+    assert name == expected_name
+
+
+@pytest.mark.parametrize(
+    "time_bucket, end_time, expected_name",
+    (
+        # For time buckets longer than a day, the hours, minutes and seconds parts
+        # should be truncated from end date.
+        (
+            TimeBucket.d1,
+            dt.datetime(2022, 8, 18, 9, 5, 11, 111222),
+            "candles-jsonl-1d-to_2022-08-18_00-00-00-c57f41e7e5bc1a97a2b09d1f326e4e27.parquet"
+        ),
+        (
+            TimeBucket.d7,
+            dt.datetime(2022, 8, 18, 12, 34, 56, 987654),
+            "candles-jsonl-7d-to_2022-08-18_00-00-00-dd6d1182e6075c6c4ce1bebf1375fcae.parquet"
+        ),
+        (
+            TimeBucket.d30,
+            dt.datetime(2022, 8, 18, 23, 59, 59, 999999),
+            "candles-jsonl-30d-to_2022-08-18_00-00-00-977074bcdc3cc020db20871d944ca183.parquet"
+        ),
+        # We omit d360, because yearly candles do not make much sense in trading and nobody
+        # uses them.
+    ),
+)
+def test__generate_cache_name_end_time_day_precision(
+    class_under_test, time_bucket, end_time, expected_name
+):
+    transport = class_under_test(download_func=Mock())
+
+    name = transport._generate_cache_name(
+        pair_ids=[10, 20, 30],
+        end_time=end_time,
+        time_bucket=time_bucket,
+    )
+
+    assert name == expected_name

--- a/tests/transport/test_cache.py
+++ b/tests/transport/test_cache.py
@@ -8,21 +8,18 @@ from tradingstrategy.timebucket import TimeBucket
 
 
 @pytest.fixture()
-def class_under_test():
+def transport():
     from tradingstrategy.transport.cache import CachedHTTPTransport
 
-    return CachedHTTPTransport
+    return CachedHTTPTransport(download_func=Mock())
 
 
-def test_get_cached_item_no_cache_file(class_under_test, tmp_path):
-    transport = class_under_test(download_func=Mock())
+def test_get_cached_item_no_cache_file(transport, tmp_path):
     filename = transport.get_cached_item(tmp_path / "not_here.parquet")
     assert filename is None
 
 
-def test_get_cached_item_cache_file_with_end_time(class_under_test, tmp_path):
-    transport = class_under_test(download_func=Mock())
-
+def test_get_cached_item_cache_file_with_end_time(transport, tmp_path):
     # Cached candle data with end time should never expire, no matter how old they are
     tmp_file = tmp_path / "candles-jsonl-1m-to_1998-03-31_19-38-02-58000fef3f0a6af9d8393f50d530d3db.parquet"
     tmp_file.write_text("I am candle data!")  # actually create the file
@@ -34,9 +31,7 @@ def test_get_cached_item_cache_file_with_end_time(class_under_test, tmp_path):
     assert filename == tmp_file
 
 
-def test_get_cached_item_cache_file_no_end_time_recent_enough(class_under_test, tmp_path):
-    transport = class_under_test(download_func=Mock())
-
+def test_get_cached_item_cache_file_no_end_time_recent_enough(transport, tmp_path):
     # Cached candle data with end time should never expire, no matter how old they are
     tmp_file = tmp_path / "candles-jsonl-1m-58000fef3f0a6af9d8393f50d530d3db.parquet"
     tmp_file.write_text("I am candle data!")  # actually create the file
@@ -47,9 +42,7 @@ def test_get_cached_item_cache_file_no_end_time_recent_enough(class_under_test, 
     assert filename == tmp_file
 
 
-def test_get_cached_item_cache_file_no_end_time_expired(class_under_test, tmp_path):
-    transport = class_under_test(download_func=Mock())
-
+def test_get_cached_item_cache_file_no_end_time_expired(transport, tmp_path):
     # Cached candle data with end time should never expire, no matter how old they are
     tmp_file = tmp_path / "candles-jsonl-1m-58000fef3f0a6af9d8393f50d530d3db.parquet"
     tmp_file.write_text("I am candle data!")  # actually create the file
@@ -82,11 +75,7 @@ def test_get_cached_item_cache_file_no_end_time_expired(class_under_test, tmp_pa
         ),
     ),
 )
-def test__generate_cache_name_no_end_time(
-    class_under_test, kwarg_overrides, expected_name
-):
-    transport = class_under_test(download_func=Mock())
-
+def test__generate_cache_name_no_end_time(transport, kwarg_overrides, expected_name):
     kwargs = {
         "pair_ids": {2, 17, 8},
         "time_bucket": TimeBucket.m1,
@@ -117,10 +106,8 @@ def test__generate_cache_name_no_end_time(
     ),
 )
 def test__generate_cache_name_end_time_minute_precision(
-    class_under_test, time_bucket, end_time, expected_name
+    transport, time_bucket, end_time, expected_name
 ):
-    transport = class_under_test(download_func=Mock())
-
     name = transport._generate_cache_name(
         pair_ids=[10, 20, 30],
         end_time=end_time,
@@ -148,10 +135,8 @@ def test__generate_cache_name_end_time_minute_precision(
     ),
 )
 def test__generate_cache_name_end_time_hour_precision(
-    class_under_test, time_bucket, end_time, expected_name
+    transport, time_bucket, end_time, expected_name
 ):
-    transport = class_under_test(download_func=Mock())
-
     name = transport._generate_cache_name(
         pair_ids=[10, 20, 30],
         end_time=end_time,
@@ -186,10 +171,8 @@ def test__generate_cache_name_end_time_hour_precision(
     ),
 )
 def test__generate_cache_name_end_time_day_precision(
-    class_under_test, time_bucket, end_time, expected_name
+    transport, time_bucket, end_time, expected_name
 ):
-    transport = class_under_test(download_func=Mock())
-
     name = transport._generate_cache_name(
         pair_ids=[10, 20, 30],
         end_time=end_time,


### PR DESCRIPTION
Closes #21.

This PR changes the candle data cache invalidation logic - if there is an end time specified, such file never expires.