### PR TITLE
Update ExchangeType enum

### DIFF
--- a/tests/test_pair_universe.py
+++ b/tests/test_pair_universe.py
@@ -3,8 +3,8 @@ import datetime
 import pytest
 
 from tradingstrategy.chain import ChainId
-from tradingstrategy.pair import LegacyPairUniverse, PairType, DEXPair, PandasPairUniverse, \
-    resolve_pairs_based_on_ticker
+from tradingstrategy.exchange import ExchangeType
+from tradingstrategy.pair import DEXPair, PandasPairUniverse, resolve_pairs_based_on_ticker
 
 
 @pytest.fixture
@@ -16,7 +16,7 @@ def sample_pair() -> DEXPair:
             exchange_slug="uniswap-v2",
             pair_slug="eth-usdc",
             address="0x0000000000000000000000000000000000000001",
-            dex_type=PairType.uniswap_v2,
+            dex_type=ExchangeType.uniswap_v2,
             base_token_symbol="WETH",
             quote_token_symbol="USDC",
             token0_decimals=6,

--- a/tests/test_stablecoin.py
+++ b/tests/test_stablecoin.py
@@ -1,7 +1,8 @@
 import datetime
 
 from tradingstrategy.chain import ChainId
-from tradingstrategy.pair import PairType, DEXPair, filter_for_stablecoins, StablecoinFilteringMode, \
+from tradingstrategy.exchange import ExchangeType
+from tradingstrategy.pair import DEXPair, filter_for_stablecoins, StablecoinFilteringMode, \
     StablecoinFilteringMode
 from tradingstrategy.stablecoin import is_stablecoin_like
 
@@ -24,7 +25,7 @@ def test_filter_stablecoin_pairs():
             chain_id=ChainId.ethereum,
             exchange_id=1,
             address="0x0000000000000000000000000000000000000000",
-            dex_type=PairType.uniswap_v2,
+            dex_type=ExchangeType.uniswap_v2,
             base_token_symbol="WETH",
             quote_token_symbol="USDC",
             token0_symbol="USDC",
@@ -46,7 +47,7 @@ def test_filter_stablecoin_pairs():
             chain_id=ChainId.ethereum,
             exchange_id=1,
             address="0x0000000000000000000000000000000000000000",
-            dex_type=PairType.uniswap_v2,
+            dex_type=ExchangeType.uniswap_v2,
             base_token_symbol="DAI",
             quote_token_symbol="USDC",
             token0_symbol="USDC",

--- a/tradingstrategy/exchange.py
+++ b/tradingstrategy/exchange.py
@@ -19,7 +19,7 @@ from tradingstrategy.chain import ChainId
 from tradingstrategy.types import NonChecksummedAddress, UNIXTimestamp, PrimaryKey
 
 
-class ExchangeType(enum.Enum):
+class ExchangeType(str, enum.Enum):
     """What kind of an decentralised exchange, AMM or other the pair is trading on.
 
     Note that each type can have multiple implementations.
@@ -27,13 +27,15 @@ class ExchangeType(enum.Enum):
     """
 
     #: Uniswap v2 style exchange
-    uniswap_v2 = "uni_v2"
+    uniswap_v2 = "uniswap_v2"
 
     #: Uniswap v3 style exchange
-    uniswap_v3 = "uni_v3"
+    uniswap_v3 = "uniswap_v3"
 
-    #: Sushiswap v3 style exchange
-    sushi_v3 = "uni_v3"
+    # Uniswap v2 style exchange (same as above `uniswap_v2`)
+    # NOTE: Do not use this member as it is deprecated and only kept for backward 
+    # compatibility, it will be removed in the future
+    _deprecated_uni_v2 = "uni_v2"
 
 
 @dataclass_json

--- a/tradingstrategy/pair.py
+++ b/tradingstrategy/pair.py
@@ -25,7 +25,7 @@ from dataclasses_json import dataclass_json
 
 from tradingstrategy.chain import ChainId
 from tradingstrategy.token import Token
-from tradingstrategy.exchange import ExchangeUniverse, Exchange
+from tradingstrategy.exchange import ExchangeUniverse, Exchange, ExchangeType
 from tradingstrategy.stablecoin import ALL_STABLECOIN_LIKE
 from tradingstrategy.types import NonChecksummedAddress, BlockNumber, UNIXTimestamp, BasisPoint, PrimaryKey
 from tradingstrategy.utils.columnar import iterate_columnar_dicts
@@ -42,20 +42,6 @@ class NoPairFound(Exception):
 
 class DuplicatePair(Exception):
     """Found multiple trading pairs for the same naive lookup."""
-
-
-class PairType(enum.Enum):
-    """What kind of an decentralised exchange, AMM or other the pair is trading on.
-
-    Note that each type can have multiple implementations.
-    For example QuickSwap, Sushi and Pancake are all Uniswap v2 types.
-    """
-
-    #: Uniswap v2 style exchange
-    uniswap_v2 = "uni_v2"
-
-    #: Uniswap v3 style exchange
-    uniswap_v3 = "uni_v3"
 
 
 @dataclass_json
@@ -126,7 +112,7 @@ class DEXPair:
     address: NonChecksummedAddress
 
     #: What kind of exchange this pair is on
-    dex_type: PairType
+    dex_type: ExchangeType
 
     #: Token pair contract address on-chain.
     #: Lowercase, non-checksummed.


### PR DESCRIPTION
* Change value `uni_v2` -> `uniswap_v2` for clarity
* Change value `uni_v3` -> `uniswap_v3` for clarity
* Keep `uni_v2` value but marked as deprecated and write a note
* Remove `PairType` as it's duplicated of `ExchangeType`