### PR TITLE
add optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.14.1
+
+- Add caching to `get_candles_by_pair()` and `get_single()` methods.
+This can result in backtesting time being more than halved. 
+
 # 0.14
 
 - Add: `tradingstrategy.utils.groupeduniverse.fix_bad_wicks` to deal with candle data where high and low

--- a/tradingstrategy/candle.py
+++ b/tradingstrategy/candle.py
@@ -329,8 +329,6 @@ class GroupedCandleUniverse(PairGroupedUniverse):
 
             - close
         """
-        if not hasattr(self, "candles_cache"):
-            self.candles_cache = {}
 
         if pair_id not in self.candles_cache:
             self.candles_cache[pair_id] = self.get_samples_by_pair(pair_id)

--- a/tradingstrategy/candle.py
+++ b/tradingstrategy/candle.py
@@ -329,7 +329,13 @@ class GroupedCandleUniverse(PairGroupedUniverse):
 
             - close
         """
-        return self.get_samples_by_pair(pair_id)
+        if not hasattr(self, "candles_cache"):
+            self.candles_cache = {}
+
+        if pair_id not in self.candles_cache:
+            self.candles_cache[pair_id] = self.get_samples_by_pair(pair_id)
+        
+        return self.candles_cache[pair_id]
 
     def get_closest_price(self,
                           pair_id: PrimaryKey,

--- a/tradingstrategy/pair.py
+++ b/tradingstrategy/pair.py
@@ -703,9 +703,12 @@ class PandasPairUniverse:
 
         :raise AssertionError: If our pair universe does not have an exact single pair
         """
-        pair_count = len(self.pair_map)
-        assert pair_count == 1, f"Not a single trading pair universe, we have {pair_count} pairs"
-        return DEXPair.from_dict(next(iter(self.pair_map.values())))
+        if not hasattr(self, "single_pair_cache"):
+            pair_count = len(self.pair_map)
+            assert pair_count == 1, f"Not a single trading pair universe, we have {pair_count} pairs"
+            self.single_pair_cache = DEXPair.from_dict(next(iter(self.pair_map.values())))
+
+        return self.single_pair_cache   
 
     def get_by_symbols(self, base_token_symbol: str, quote_token_symbol: str) -> Optional[DEXPair]:
         """For strategies that trade only a few trading pairs, get the only pair in the universe.

--- a/tradingstrategy/pair.py
+++ b/tradingstrategy/pair.py
@@ -549,6 +549,8 @@ class PandasPairUniverse:
 
         self.exchange_universe = exchange_universe
 
+        self.single_pair_cache: DEXPair = None
+
     def iterate_pairs(self) -> Iterable[DEXPair]:
         """Iterate over all pairs in this universe."""
         for pair_id in self.pair_map.keys():
@@ -703,12 +705,13 @@ class PandasPairUniverse:
 
         :raise AssertionError: If our pair universe does not have an exact single pair
         """
-        if not hasattr(self, "single_pair_cache"):
-            pair_count = len(self.pair_map)
-            assert pair_count == 1, f"Not a single trading pair universe, we have {pair_count} pairs"
-            self.single_pair_cache = DEXPair.from_dict(next(iter(self.pair_map.values())))
+        if self.single_pair_cache:
+            return self.single_pair_cache 
 
-        return self.single_pair_cache   
+        pair_count = len(self.pair_map)
+        assert pair_count == 1, f"Not a single trading pair universe, we have {pair_count} pairs"
+        self.single_pair_cache = DEXPair.from_dict(next(iter(self.pair_map.values())))
+
 
     def get_by_symbols(self, base_token_symbol: str, quote_token_symbol: str) -> Optional[DEXPair]:
         """For strategies that trade only a few trading pairs, get the only pair in the universe.

--- a/tradingstrategy/pair.py
+++ b/tradingstrategy/pair.py
@@ -711,6 +711,7 @@ class PandasPairUniverse:
         pair_count = len(self.pair_map)
         assert pair_count == 1, f"Not a single trading pair universe, we have {pair_count} pairs"
         self.single_pair_cache = DEXPair.from_dict(next(iter(self.pair_map.values())))
+        return self.single_pair_cache
 
 
     def get_by_symbols(self, base_token_symbol: str, quote_token_symbol: str) -> Optional[DEXPair]:

--- a/tradingstrategy/utils/groupeduniverse.py
+++ b/tradingstrategy/utils/groupeduniverse.py
@@ -78,6 +78,9 @@ class PairGroupedUniverse:
         self.timestamp_column = timestamp_column
         self.time_bucket = time_bucket
 
+        self.candles_cache: dict[int, pd.DataFrame] = {}
+
+
     def get_columns(self) -> pd.Index:
         """Get column names from the underlying pandas.GroupBy object"""
         return self.pairs.obj.columns


### PR DESCRIPTION
- small PR that can more than halve backtesting time
- caches candles by pair id instead of fetching them using expensive pandas methods