### PR TITLE
allow summary table to have multiple columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.17.6
+
+- Allows summary table from `create_summmary_table()` to have multiple columns
+- Split duration into days_hours for positions that are longer than 1 day, and hours_minutes for durations that are shorter than a day
+
 # 0.17.5
 
 - Fix test warnings by changing function calls from `create_single_pair_universe()` to `create_pair_universe()`

--- a/tests/unit_tests/test_create_summary_table.py
+++ b/tests/unit_tests/test_create_summary_table.py
@@ -1,4 +1,5 @@
 import datetime
+import pandas as pd
 from tradingstrategy.utils.summarydataframe import (
     create_summary_table,
     as_dollar,
@@ -20,10 +21,17 @@ def test_create_summary_table_single_column():
 
     assert df.shape == (4, 1)
 
+    data = ["10.00%", "30.00%", "$320.00", "5 days 2 hours"]
+    index = ["Annualised return %", "Lifetime return %", "Realised PnL", "Trade period"]
+    manual_df = pd.DataFrame(data, index=index)
+    manual_df.index.name="Returns"
+    manual_df.columns = [""]
+    assert df.equals(manual_df)
+
 
 def test_create_summary_table_multiple_columns():
     
-    data3 = {
+    data = {
         "Number of positions": [
             as_integer(3),
             as_integer(5),
@@ -41,8 +49,14 @@ def test_create_summary_table_multiple_columns():
         ],
     }
 
-    df3 = create_summary_table(
-        data3, ["Winning", "Losing", "Total"], "Closed Positions"
+    df = create_summary_table(
+        data, ["Winning", "Losing", "Total"], "Closed Positions"
     )
 
-    assert df3.shape == (3, 3)
+    assert df.shape == (3, 3)
+
+    data = [["3", "5", "8"], ["37.50%", "62.50%", "100.00%"], ["6.00%", "-2.00%", "3.00%"]]
+    index = ["Number of positions", "% of total", "Average PnL %"]
+    manual_df = pd.DataFrame(data, index=index, columns=["Winning", "Losing", "Total"])
+    manual_df.index.name="Closed Positions"
+    assert df.equals(manual_df)

--- a/tests/unit_tests/test_create_summary_table.py
+++ b/tests/unit_tests/test_create_summary_table.py
@@ -23,9 +23,8 @@ def test_create_summary_table_single_column():
 
     data = ["10.00%", "30.00%", "$320.00", "5 days 2 hours"]
     index = ["Annualised return %", "Lifetime return %", "Realised PnL", "Trade period"]
-    manual_df = pd.DataFrame(data, index=index)
+    manual_df = pd.DataFrame(data, index=index, columns=[""])
     manual_df.index.name="Returns"
-    manual_df.columns = [""]
     assert df.equals(manual_df)
 
 

--- a/tests/unit_tests/test_create_summary_table.py
+++ b/tests/unit_tests/test_create_summary_table.py
@@ -1,0 +1,48 @@
+import datetime
+from tradingstrategy.utils.summarydataframe import (
+    create_summary_table,
+    as_dollar,
+    as_duration,
+    as_percent,
+    as_integer
+)
+
+
+def test_create_summary_table_single_column():
+    data = {
+        "Annualised return %": as_percent(0.1),
+        "Lifetime return %": as_percent(0.3),
+        "Realised PnL": as_dollar(320),
+        "Trade period": as_duration(datetime.timedelta(days=5, hours=2, minutes=3)),
+    }
+
+    df = create_summary_table(data, "", "Returns")
+
+    assert df.shape == (4, 1)
+
+
+def test_create_summary_table_multiple_columns():
+    
+    data3 = {
+        "Number of positions": [
+            as_integer(3),
+            as_integer(5),
+            as_integer(8),
+        ],
+        "% of total": [
+            as_percent(0.375),
+            as_percent(0.625),
+            as_percent(1),
+        ],
+        "Average PnL %": [
+            as_percent(0.06),
+            as_percent(-0.02),
+            as_percent(0.03),
+        ],
+    }
+
+    df3 = create_summary_table(
+        data3, ["Winning", "Losing", "Total"], "Closed Positions"
+    )
+
+    assert df3.shape == (3, 3)

--- a/tradingstrategy/utils/summarydataframe.py
+++ b/tradingstrategy/utils/summarydataframe.py
@@ -66,6 +66,12 @@ def as_missing() -> Value:
     return Value(None, Format.missing)
 
 def format_value(v_instance: Value) -> str:
+    """Format a single value
+    
+    :param v_instance: A :py:class:`Value` instance
+    
+    :return: A formatted string
+    """
     assert isinstance(v_instance, Value), f"Expected Value instance, got {v_instance}"
     formatter = FORMATTERS[v_instance.format]
     if v_instance.v is not None:
@@ -79,17 +85,31 @@ def format_value(v_instance: Value) -> str:
         return FORMATTERS[Format.missing].format(v=v_instance.v)
     
 def format_values(values: list[Value]) -> list[str]:
+    """Format a list of values
+    
+    :param values: A list of :py:class:`Value` instances
+
+    :return: A list of formatted strings
+    """
     return [format_value(v) for v in values]
 
 
-def create_summary_table(data: dict) -> pd.DataFrame:
+def create_summary_table(data: dict, column_names: list[str] | str | None = None, index_name: str | None = None) -> pd.DataFrame:
     """Create a summary table from a human readable data.
 
     * Keys are human readable labels
 
     * Values are instances of :py:class:`Value`
 
-    TODO: We get column header "zero" that needs to be hidden.
+    TODO: If column_names is not provided, we get column header "zero" that needs to be hidden.
+
+    :param data: Human readable data in the form of a dict
+
+    :param column_names: Column names for the dataframe. If None, no column names are used.
+
+    :param index_name: Name of the index column. If None, no index name is used.
+
+    :return: A styled pandas dataframe
     """
 
     formatted_data = {}
@@ -109,6 +129,13 @@ def create_summary_table(data: dict) -> pd.DataFrame:
         counter += 1
 
     df = pd.DataFrame.from_dict(formatted_data, orient="index")
+    if column_names is not None:
+        if isinstance(column_names, str):
+            column_names = [column_names]
+        df.columns = column_names
+    if index_name is not None:
+        df.index.name = index_name
+
     # https://pandas.pydata.org/docs/dev/reference/api/pandas.io.formats.style.Styler.hide.html
     df.style.hide(axis="index", names=True)
     df.style.hide(axis="columns", names=False)

--- a/tradingstrategy/utils/summarydataframe.py
+++ b/tradingstrategy/utils/summarydataframe.py
@@ -14,7 +14,8 @@ class Format(enum.Enum):
     integer = "int"
     percent = "percent"
     dollar = "dollar"
-    duration = "duration"
+    duration_days_hours = "duration_days_hours"
+    duration_hours_minutes = "duration_hours_minutes"
     num_bars = "num_bars"
 
     #: Value cannot be calculated, e.g division by zero
@@ -26,7 +27,8 @@ FORMATTERS = {
     Format.integer: "{v:.0f}",
     Format.percent: "{v:.2%}",
     Format.dollar: "${v:,.2f}",
-    Format.duration: "{v.days} days",
+    Format.duration_days_hours: "{days} days {hours} hours",
+    Format.duration_hours_minutes: "{hours} hours {minutes} minutes",
     Format.num_bars: "{v:.0f} bars",
     Format.missing: "-",
 }
@@ -55,7 +57,10 @@ def as_percent(v) -> Value:
 
 def as_duration(v: datetime.timedelta) -> Value:
     """Format value as a duration"""
-    return Value(v, Format.duration)
+    if v.days > 0:
+        return Value(v, Format.duration_days_hours)
+    else:
+        return Value(v, Format.duration_hours_minutes)
 
 def as_bars(v: float) -> Value:
     """Format value as number of bars"""
@@ -77,7 +82,7 @@ def format_value(v_instance: Value) -> str:
     if v_instance.v is not None:
         # TODO: Remove the hack
         if isinstance(v_instance.v, datetime.timedelta):
-            return formatter.format(v=v_instance.v)
+            return formatter.format(days=v_instance.v.days, hours=v_instance.v.seconds // 3600, minutes=(v_instance.v.seconds // 60) % 60)
         else:
             return formatter.format(v=float(v_instance.v))
     else:

--- a/tradingstrategy/utils/summarydataframe.py
+++ b/tradingstrategy/utils/summarydataframe.py
@@ -77,6 +77,9 @@ def format_value(v_instance: Value) -> str:
     else:
         # missing values
         return FORMATTERS[Format.missing].format(v=v_instance.v)
+    
+def format_values(values: list[Value]) -> list[str]:
+    return [format_value(v) for v in values]
 
 
 def create_summary_table(data: dict) -> pd.DataFrame:
@@ -88,7 +91,23 @@ def create_summary_table(data: dict) -> pd.DataFrame:
 
     TODO: We get column header "zero" that needs to be hidden.
     """
-    formatted_data = {k: format_value(v) for k, v in data.items()}
+
+    formatted_data = {}
+    counter = 0
+    list_length = 0
+    for k, v in data.items():
+        if isinstance(v, Value):
+            formatted_data[k] = format_value(v)
+        elif isinstance(v, list):
+            if counter == 0:
+                list_length = len(v)
+            else:
+                assert len(v) == list_length, f"If one value in the dict is a list, all values must be lists of the same length. Expected list of length {list_length}, got {v}"
+            
+            formatted_data[k] = format_values(v)
+
+        counter += 1
+
     df = pd.DataFrame.from_dict(formatted_data, orient="index")
     # https://pandas.pydata.org/docs/dev/reference/api/pandas.io.formats.style.Styler.hide.html
     df.style.hide(axis="index", names=True)


### PR DESCRIPTION
### Details

- allows formatting a list of values
- allows summary table to have multiple columns

![Screenshot from 2023-07-04 16-25-12](https://github.com/tradingstrategy-ai/trading-strategy/assets/74208897/947f2813-d2a3-4d4c-9930-7ffb0b17d0d3)

- Also, split duration into `days_hours` for positions that are longer than 1 day, and `hours_minutes` for durations that are shorter than a day

### Tasks

- fixes https://github.com/tradingstrategy-ai/trade-executor/issues/424