### PR TITLE
Refactor mock client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.20.3
+
+- Refactor some common code from GenericMockClient and UniswapV2MockClient into MockClient. Note: GenericMockClient resides in tradeexecutor due to its reliance on certain imports
+
 # 0.20.2
 
 - Add vToken details to Aave lending reserves

--- a/tests/mock_client/test_uniswap_v2_mock_client.py
+++ b/tests/mock_client/test_uniswap_v2_mock_client.py
@@ -160,6 +160,7 @@ def test_uniswap_v2_mock_client(
         uniswap_v2.router.address,
         uniswap_v2.init_code_hash,
     )
+    client.set_exchange_universe_and_pairs_table()
 
     exchange_universe = client.fetch_exchange_universe()
     assert len(exchange_universe.exchanges) == 1

--- a/tests/mock_client/test_uniswap_v2_mock_client.py
+++ b/tests/mock_client/test_uniswap_v2_mock_client.py
@@ -160,7 +160,7 @@ def test_uniswap_v2_mock_client(
         uniswap_v2.router.address,
         uniswap_v2.init_code_hash,
     )
-    client.set_exchange_universe_and_pairs_table()
+    client.fetch_exchange_universe_and_pairs_table()
 
     exchange_universe = client.fetch_exchange_universe()
     assert len(exchange_universe.exchanges) == 1

--- a/tradingstrategy/exchange.py
+++ b/tradingstrategy/exchange.py
@@ -229,6 +229,10 @@ class ExchangeUniverse:
     #: Exchange id -> Exchange data mapping
     exchanges: Dict[PrimaryKey, Exchange]
 
+    def __post_init__(self):
+        for exchange_id, exchange in self.exchanges.items():
+            assert exchange_id == exchange.exchange_id, "Exchange id mismatch"
+
     @staticmethod
     def from_collection(exchanges: Collection[Exchange]) -> "ExchangeUniverse":
         """Create exchange universe from a collection of exchanges."""

--- a/tradingstrategy/testing/mock_client.py
+++ b/tradingstrategy/testing/mock_client.py
@@ -12,6 +12,8 @@ from pyarrow import Table
 
 from tradingstrategy.client import BaseClient
 from tradingstrategy.timebucket import TimeBucket
+from tradingstrategy.exchange import ExchangeUniverse
+from tradingstrategy.pair import PandasPairUniverse
 
 
 class MockClientNotImplemented(NotImplementedError):
@@ -20,12 +22,6 @@ class MockClientNotImplemented(NotImplementedError):
 
 class MockClient(BaseClient):
     """Have all methods marked as not implemented"""
-
-    def fetch_exchange_universe(self):
-        raise MockClientNotImplemented()
-
-    def fetch_pair_universe(self):
-        raise MockClientNotImplemented()
 
     def fetch_all_candles(self):
         raise MockClientNotImplemented()
@@ -41,6 +37,35 @@ class MockClient(BaseClient):
 
     def fetch_all_liquidity_samples(self, bucket: TimeBucket) -> Table:
         raise MockClientNotImplemented()
+    
+    def get_default_quote_token_address(self, factory_address: str | None = None) -> str:
+        """Get the quote token address used in the generated pair map.
+
+        Helper method for setting up simple local dev routing.
+
+        Returns a the first quote token address found in the pair universe.
+
+        :param factory_address:
+            The factory address to get the quote token address from.
+        """
+        quote_tokens = []
+        pairs_df = self.fetch_pair_universe().to_pandas()
+        pair_universe = PandasPairUniverse(pairs_df)
+        assert pair_universe.get_count() > 0, "Pair universe has no trading pairs"
+        for pair in pair_universe.iterate_pairs():
+            if factory_address:
+                if pair.exchange_address.lower() == factory_address.lower():
+                    quote_tokens.append(pair.quote_token_address)
+            else:
+                quote_tokens.append(pair.quote_token_address)
+        #assert len(quote_tokens) == 1, f"Got {len(quote_tokens)} quote tokens in the pair universe, the pair universe is total {pair_universe.get_count()} pairs"
+        return quote_tokens[0]
+
+    def fetch_exchange_universe(self) -> ExchangeUniverse:
+        return self.exchange_universe
+
+    def fetch_pair_universe(self) -> Table:
+        return self.pairs_table
 
 
 

--- a/tradingstrategy/testing/uniswap_v2_mock_client.py
+++ b/tradingstrategy/testing/uniswap_v2_mock_client.py
@@ -66,7 +66,7 @@ class UniswapV2MockClient(MockClient):
         self.init_code_hash = init_code_hash
         self.fee = fee
         
-    def set_exchange_universe_and_pairs_table(self):
+    def fetch_exchange_universe_and_pairs_table(self):
         self.exchange_universe, self.pairs_table = UniswapV2MockClient.read_onchain_data(
             self.web3,
             self.factory_address,

--- a/tradingstrategy/testing/uniswap_v2_mock_client.py
+++ b/tradingstrategy/testing/uniswap_v2_mock_client.py
@@ -69,28 +69,6 @@ class UniswapV2MockClient(MockClient):
         )
         assert len(self.pairs_table) > 0, f"Could not read any pairs from on-chain data. Uniswap v2 factory: {factory_address}, router: {router_address}."
 
-    def get_default_quote_token_address(self) -> str:
-        """Get the quote token address used in the generated pair map.
-
-        Helper method for setting up simple local dev routing.
-
-        Returns a the first quote token address found in the pair universe.
-        """
-        quote_tokens = []
-        pairs_df = self.fetch_pair_universe().to_pandas()
-        pair_universe = PandasPairUniverse(pairs_df)
-        assert pair_universe.get_count() > 0, "Pair universe has no trading pairs"
-        for pair in pair_universe.iterate_pairs():
-            quote_tokens.append(pair.quote_token_address)
-        #assert len(quote_tokens) == 1, f"Got {len(quote_tokens)} quote tokens in the pair universe, the pair universe is total {pair_universe.get_count()} pairs"
-        return quote_tokens[0]
-
-    def fetch_exchange_universe(self) -> ExchangeUniverse:
-        return self.exchange_universe
-
-    def fetch_pair_universe(self) -> Table:
-        return self.pairs_table
-
     @staticmethod
     def read_onchain_data(
                 web3: Web3,

--- a/tradingstrategy/testing/uniswap_v2_mock_client.py
+++ b/tradingstrategy/testing/uniswap_v2_mock_client.py
@@ -59,15 +59,22 @@ class UniswapV2MockClient(MockClient):
         assert factory_address is not None, "factory_address not set"
         assert router_address is not None, "router_address not set"
         assert init_code_hash is not None, "init_code_hash not set"
-
+        
+        self.web3 = web3
+        self.factory_address = factory_address
+        self.router_address = router_address
+        self.init_code_hash = init_code_hash
+        self.fee = fee
+        
+    def set_exchange_universe_and_pairs_table(self):
         self.exchange_universe, self.pairs_table = UniswapV2MockClient.read_onchain_data(
-            web3,
-            factory_address,
-            router_address,
-            init_code_hash,
-            fee,
+            self.web3,
+            self.factory_address,
+            self.router_address,
+            self.init_code_hash,
+            self.fee,
         )
-        assert len(self.pairs_table) > 0, f"Could not read any pairs from on-chain data. Uniswap v2 factory: {factory_address}, router: {router_address}."
+        assert len(self.pairs_table) > 0, f"Could not read any pairs from on-chain data. Uniswap v2 factory: {self.factory_address}, router: {self.router_address}."
 
     @staticmethod
     def read_onchain_data(


### PR DESCRIPTION
- refactor some common code from `GenericMockClient` and `UniswapV2MockClient` into `MockClient`
- Note: `GenericMockClient` resides in Tradeexecutor due to its reliance on certain imports