### PR TITLE
update candle mapping (undeprecate volume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Current
+# 0.20.15
 
 - Update candle mappings so volume doesn't get set to None
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Current
+
+- Update candle mappings so volume doesn't get set to None
+
 # 0.20.14
 
 - Internal change: move `make_clickable` to module level, so it can be reused

--- a/tradingstrategy/transport/jsonl.py
+++ b/tradingstrategy/transport/jsonl.py
@@ -41,7 +41,7 @@ CANDLE_MAPPINGS = {
     "sb": "start_block",
     "eb": "end_block",
     "tc": None,  # Currently not available for Uni v3 exchanges
-    "v": None,  # Deprecated
+    "v": "volume",  # TODO deprecate
 }
 
 


### PR DESCRIPTION
Uniswap v3 data still uses volume instead of buy/sell volume, so undeprecate