### PR TITLE
Correctly handle lending data gaps in Aave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.21.1
+
+- Fix `estimate_accrued_interest` crashing when there are gaps in data
+- Fix `resample_candles` to retain `pair_id` column if one is present in data
+
 # 0.21
 
 - Add functionality for downloading and manipulating Binance candle and lending data

--- a/tradingstrategy/candle.py
+++ b/tradingstrategy/candle.py
@@ -635,6 +635,7 @@ class GroupedCandleUniverse(PairGroupedUniverse):
 
         Useful for synthetic data/testing.
         """
+        assert "pair_id" in df.columns, f"Columns lack pair_id: {df.columns}"
         return GroupedCandleUniverse(df, time_bucket=bucket)
 
     @staticmethod

--- a/tradingstrategy/client.py
+++ b/tradingstrategy/client.py
@@ -613,6 +613,11 @@ class Client(BaseClient):
         # Try file system stored API key,
         # if not prompt interactively
         if not api_key:
+            assert settings_path, \
+                "Trading Strategy API key not given as TRADING_STRATEGY_API_KEY environment variable or an argument.\n" \
+                "Interactive setup is disabled for this data client.\n" \
+                "Cannot continue."
+
             config = env.setup_on_demand(api_key=api_key)
             api_key = config.api_key
 

--- a/tradingstrategy/utils/groupeduniverse.py
+++ b/tradingstrategy/utils/groupeduniverse.py
@@ -733,7 +733,7 @@ def resample_series(series: pd.Series, new_timedelta: pd.Timedelta, forward_fill
     return candles
 
 
-def resample_candles(df: pd.DataFrame, new_timedelta: pd.Timedelta) -> pd.DataFrame:
+def resample_candles(df: pd.DataFrame, resample_freq: pd.Timedelta) -> pd.DataFrame:
     """Downsample or upsample OHLCV candles or liquidity samples.
 
     E.g. transform 1h candles to 24h candles.
@@ -750,28 +750,57 @@ def resample_candles(df: pd.DataFrame, new_timedelta: pd.Timedelta) -> pd.DataFr
         monthly_candles = resample_candles(single_pair_candles, TimeBucket.d30)
         assert len(monthly_candles) <= len(single_pair_candles) / 4
 
+    :param df:
+        DataFrame of price, liquidity or lending rate candles.
+
+        Supported columns: open, high, low, close.
+        Optional: pair_id, volume.
+
+    :param resample_freq:
+        Resample frequency
+
+    :return:
+        Candles in the new time frame.
+
+        Contains an added `timestamp` column that is also the index.
+
     """
     
-    assert isinstance(new_timedelta, pd.Timedelta), f"We got {new_timedelta}, supposed to be pd.Timedelta. E.g. pd.Timedelta(hours=2)"
+    assert isinstance(resample_freq, pd.Timedelta), f"We got {resample_freq}, supposed to be pd.Timedelta. E.g. pd.Timedelta(hours=2)"
+
+    # Sanity check we don't try to resample mixed data of multiple pairs
+    if "pair_id" in df.columns:
+        pair_ids = df["pair_id"].unique()
+        assert len(pair_ids) == 1, f"Must have single pair_id only"
+        pair_id = pair_ids[0]
+    else:
+        pair_id = None
 
     ohlc_dict = {
         'open': 'first',
         'high': 'max',
         'low': 'min',
         'close': 'last',
-        'volume': 'sum',
     }
 
+    if "volume" in df.columns:
+        ohlc_dict["volume"] = "sum"
+
     columns = df.columns.tolist()
-    assert all(item in columns for item in list(ohlc_dict.keys())), f"{list(ohlc_dict.keys())} needs to be in the column names"
+    assert all(item in columns for item in list(ohlc_dict.keys())), \
+        f"{list(ohlc_dict.keys())} needs to be in the column names\n" \
+        f"We got columns: {df.columns.tolist()}"
 
     #pandas_time_delta = new_bucket.to_pandas_timedelta()
     # https://stackoverflow.com/questions/21140630/resampling-trade-data-into-ohlcv-with-pandas
-    candles = df.resample(new_timedelta).agg(ohlc_dict) 
+    candles = df.resample(resample_freq).agg(ohlc_dict)
 
     # TODO: Figure out right way to preserve timestamp column,
     # resample seems to destroy it
     candles["timestamp"] = candles.index
+
+    if pair_id:
+        candles["pair_id"] = pair_id
 
     return candles
 

--- a/tradingstrategy/utils/groupeduniverse.py
+++ b/tradingstrategy/utils/groupeduniverse.py
@@ -736,12 +736,13 @@ def resample_series(series: pd.Series, new_timedelta: pd.Timedelta, forward_fill
 def resample_candles(df: pd.DataFrame, resample_freq: pd.Timedelta) -> pd.DataFrame:
     """Downsample or upsample OHLCV candles or liquidity samples.
 
-    E.g. transform 1h candles to 24h candles.
+    E.g. upsample 1h candles to 1d candles.
 
     Example:
 
     .. code-block:: python
 
+        # Transform daily candles to monthly candles
         from tradingstrategy.utils.groupeduniverse import resample_candles
 
         single_pair_candles = raw_candles.loc[raw_candles["pair_id"] == pair.pair_id]
@@ -791,7 +792,6 @@ def resample_candles(df: pd.DataFrame, resample_freq: pd.Timedelta) -> pd.DataFr
         f"{list(ohlc_dict.keys())} needs to be in the column names\n" \
         f"We got columns: {df.columns.tolist()}"
 
-    #pandas_time_delta = new_bucket.to_pandas_timedelta()
     # https://stackoverflow.com/questions/21140630/resampling-trade-data-into-ohlcv-with-pandas
     candles = df.resample(resample_freq).agg(ohlc_dict)
 


### PR DESCRIPTION
- Fix `estimate_accrued_interest` crashing when there are gaps in data
- Fix `resample_candles` to retain `pair_id` column if one is present in data