### PR TITLE
Add Binace asset trade start date fetcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Current
+
+- Add: `BinanceDownloader.fetch_approx_asset_trading_start_date()` to figure out when asset was listed on Binance
+- Fix: `BinanceDownloader` timestamps to be UTC
+- Add: Example script how to download Binance data for multiple assets and write in a single Parquet file
+
 # 0.21.1
 
 - Fix `estimate_accrued_interest` crashing when there are gaps in data

--- a/scripts/fetch-binance-candles.py
+++ b/scripts/fetch-binance-candles.py
@@ -41,6 +41,7 @@ total_size = 0
 with tqdm(total=len(pairs)) as progress_bar:
     for symbol in pairs:
 
+        start = downloader.fetch_approx_asset_trading_start_date(symbol)
         end = datetime.datetime.utcnow() - datetime.timedelta(hours=24)
 
         # Fetch data for this pair, or use the cached file if already downloaded earlier

--- a/scripts/fetch-binance-candles.py
+++ b/scripts/fetch-binance-candles.py
@@ -8,6 +8,7 @@ import datetime
 import os
 
 import pandas as pd
+from IPython.core.display_functions import display
 from tqdm.auto import tqdm
 
 from tradingstrategy.binance_data import BinanceDownloader
@@ -30,7 +31,7 @@ pairs = {
 }
 
 time_bucket = TimeBucket.d1
-pair_hash = hash(pairs)
+pair_hash = hex(hash("".join(sorted(list(pairs)))))  # If we change any of pairs the filename must change
 fpath = f"/tmp/binance-candles-{time_bucket.value}-{pair_hash}.parquet"
 
 downloader = BinanceDownloader()
@@ -50,18 +51,30 @@ with tqdm(total=len(pairs)) as progress_bar:
         # Label the dataset with the ticker we downloaded,
         # so we can group pairs in the flattened file
         df["pair_id"] = symbol
+        df["timestamp"] = df.index.copy()  # We need to preserve this in the flattening later
 
         # Count the cached file size
         path = downloader.get_parquet_path(symbol, time_bucket, start, end)
         total_size += os.path.getsize(path)
 
+        parts.append(df)
+
         progress_bar.set_postfix({"pair": symbol, "total_size (MBytes)": total_size / (1024**2)})
         progress_bar.update()
 
 flattened_df = pd.concat(parts)
-flattened_df = flattened_df.reset_index().set_index("timestamp")  # Get rid of grouping
+flattened_df = flattened_df.set_index("timestamp")  # Get rid of grouping
+flattened_df = flattened_df.sort_values(by=["pair_id", "timestamp"])  # Arrange data for maximum columnar compression
 flattened_df.to_parquet(fpath)
-print(f"Wrote {fpath} {os.path.getsize(fpath):,} bytes")
+
+first_candle_at = flattened_df.index.min()
+last_candle_at = flattened_df.index.max()
+
+# Display sample data, the first entry for each trading pair
+sample_data_df = flattened_df.drop_duplicates("pair_id")
+display(sample_data_df)
+
+print(f"Total {len(flattened_df):,} candles, between {first_candle_at} - {last_candle_at}, wrote {fpath} {os.path.getsize(fpath):,} bytes")
 
 
 

--- a/scripts/fetch-binance-candles.py
+++ b/scripts/fetch-binance-candles.py
@@ -1,0 +1,66 @@
+"""An example script to download Binance daily data for given set of pairs.
+
+- Download spot market OHLCV data from Binance public API endpoint
+
+- Create a combined Parquet file for all pairs.
+"""
+import datetime
+import os
+
+import pandas as pd
+from tqdm.auto import tqdm
+
+from tradingstrategy.binance_data import BinanceDownloader
+from tradingstrategy.timebucket import TimeBucket
+
+# Choose 10 well-known pairs
+pairs = {
+    "ETHUSDT",
+    "BTCUSDT",
+    "LINKUSDT",
+    "MATICUSDT",
+    "AAVEUSDT",
+    "COMPUSDT",
+    "MKRUSDT",
+    "BNBUSDT",
+    "AVAXUSDT",
+    "CAKEUSDT",
+    "SNXUSDT",
+    "CRVUSDT",
+}
+
+time_bucket = TimeBucket.d1
+pair_hash = hash(pairs)
+fpath = f"/tmp/binance-candles-{time_bucket.value}-{pair_hash}.parquet"
+
+downloader = BinanceDownloader()
+
+parts = []
+total_size = 0
+
+with tqdm(total=len(pairs)) as progress_bar:
+    for symbol in pairs:
+
+        end = datetime.datetime.utcnow() - datetime.timedelta(hours=24)
+
+        # Fetch data for this pair, or use the cached file if already downloaded earlier
+        df = downloader.fetch_candlestick_data(symbol, time_bucket, start, end)
+
+        # Label the dataset with the ticker we downloaded,
+        # so we can group pairs in the flattened file
+        df["pair_id"] = symbol
+
+        # Count the cached file size
+        path = downloader.get_parquet_path(symbol, time_bucket, start, end)
+        total_size += os.path.getsize(path)
+
+        progress_bar.set_postfix({"pair": symbol, "total_size (MBytes)": total_size / (1024**2)})
+        progress_bar.update()
+
+flattened_df = pd.concat(parts)
+flattened_df = flattened_df.reset_index().set_index("timestamp")  # Get rid of grouping
+flattened_df.to_parquet(fpath)
+print(f"Wrote {fpath} {os.path.getsize(fpath):,} bytes")
+
+
+

--- a/tests/test_binance_data.py
+++ b/tests/test_binance_data.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 from unittest.mock import patch, Mock
 
-from tradingstrategy.binance_data import BinanceDownloader
+from tradingstrategy.binance_data import BinanceDownloader, BinanceDataFetchError
 from tradingstrategy.timebucket import TimeBucket
 
 
@@ -169,3 +169,17 @@ def test_starting_date(candle_downloader: BinanceDownloader):
 
     curve_starting_date = candle_downloader.fetch_approx_asset_trading_start_date("CRVUSDT")
     assert curve_starting_date == datetime.datetime(2020, 8, 1, 0, 0)
+
+
+@pytest.mark.skipif(os.environ.get("GITHUB_ACTIONS", None) == "true", reason="Github US servers are blocked by Binance")
+def test_starting_date_unknown(candle_downloader: BinanceDownloader):
+    """Test purging cached candle data. Must be run after test_read_fresh_candle_data and test_read_cached_candle_data.
+
+    Checks that deleting cached data works correctly.
+    """
+
+    # Unknown asset
+    with pytest.raises(BinanceDataFetchError):
+        candle_downloader.fetch_approx_asset_trading_start_date("FOOBAR")
+
+

--- a/tests/test_binance_data.py
+++ b/tests/test_binance_data.py
@@ -154,3 +154,18 @@ def test_purge_cache(candle_downloader: BinanceDownloader):
 
     candle_downloader.purge_all_cached_data()
     assert len(list(candle_downloader.cache_directory.iterdir())) == 0
+
+
+@pytest.mark.skipif(os.environ.get("GITHUB_ACTIONS", None) == "true", reason="Github US servers are blocked by Binance")
+def test_starting_date(candle_downloader: BinanceDownloader):
+    """Test purging cached candle data. Must be run after test_read_fresh_candle_data and test_read_cached_candle_data.
+
+    Checks that deleting cached data works correctly.
+    """
+
+    # Longest living asset
+    btc_starting_date = candle_downloader.fetch_approx_asset_trading_start_date("BTCUSDT")
+    assert btc_starting_date == datetime.datetime(2017, 8, 1, 0, 0)
+
+    curve_starting_date = candle_downloader.fetch_approx_asset_trading_start_date("CRVUSDT")
+    assert curve_starting_date == datetime.datetime(2020, 8, 1, 0, 0)


### PR DESCRIPTION
- Add: `BinanceDownloader.fetch_approx_asset_trading_start_date()` to figure out when asset was listed on Binance
- Fix: `BinanceDownloader` timestamps to be UTC
- Add: Example script how to download Binance data for multiple assets and write in a single Parquet file