### PR TITLE
Override default binance urls

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -42,3 +42,5 @@ jobs:
         poetry run pytest --tb=native -n 6
       env:
         TRADING_STRATEGY_API_KEY: ${{ secrets.TRADING_STRATEGY_API_KEY }}
+        BASE_BINANCE_API_URL: ${{ secrets.BASE_BINANCE_API_URL }}
+        BASE_BINANCE_MARGIN_API_URL: ${{ secrets.BASE_BINANCE_MARGIN_API_URL }}

--- a/tests/test_binance_data.py
+++ b/tests/test_binance_data.py
@@ -266,10 +266,6 @@ def test_purge_cache():
         assert len(list(candle_downloader.cache_directory.iterdir())) == 0
 
 
-@pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", None) == "true",
-    reason="Github US servers are blocked by Binance",
-)
 def test_starting_date(candle_downloader: BinanceDownloader):
     """Test purging cached candle data. Must be run after test_read_fresh_candle_data and test_read_cached_candle_data.
 
@@ -288,10 +284,6 @@ def test_starting_date(candle_downloader: BinanceDownloader):
     assert curve_starting_date == datetime.datetime(2020, 8, 1, 0, 0)
 
 
-@pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", None) == "true",
-    reason="Github US servers are blocked by Binance",
-)
 def test_starting_date_unknown(candle_downloader: BinanceDownloader):
     """Test purging cached candle data. Must be run after test_read_fresh_candle_data and test_read_cached_candle_data.
 
@@ -303,10 +295,6 @@ def test_starting_date_unknown(candle_downloader: BinanceDownloader):
         candle_downloader.fetch_approx_asset_trading_start_date("FOOBAR")
 
 
-@pytest.mark.skipif(
-    os.environ.get("GITHUB_ACTIONS", None) == "true",
-    reason="Github US servers are blocked by Binance",
-)
 def test_fetch_assets(candle_downloader: BinanceDownloader):
     """Get available tradeable assets on Binance."""
     assets = list(candle_downloader.fetch_assets())
@@ -376,7 +364,6 @@ def test_generate_lending_reserve():
     assert reserve.chain_id == ChainId.centralised_exchange
 
 
-@pytest.mark.skipif(os.environ.get("GITHUB_ACTIONS", None) == "true", reason="Github US servers are blocked by Binance with HTTP 451")
 def test_fetch_binance_price_data_multipair():
     """Check that pair data for multipair looks correct.
 

--- a/tradingstrategy/binance/downloader.py
+++ b/tradingstrategy/binance/downloader.py
@@ -34,6 +34,10 @@ from tradingstrategy.binance.constants import BINANCE_SUPPORTED_QUOTE_TOKENS, sp
 logger = logging.getLogger(__name__)
 
 
+BASE_BINANCE_API_URL = os.getenv("BASE_BINANCE_API_URL", "https://api.binance.com")
+BASE_BINANCE_MARGIN_API_URL = os.getenv("BASE_BINANCE_MARGIN_API_URL", "https://www.binance.com/bapi/margin")
+
+
 class BinanceDataFetchError(ValueError):
     """Something wrong with Binance."""
 
@@ -48,7 +52,8 @@ class BinanceDownloader:
         """Initialize BinanceCandleDownloader and create folder for cached data if it does not exist."""
         cache_directory.mkdir(parents=True, exist_ok=True)
         self.cache_directory = cache_directory
-        self.api_server = "api.binance.com"
+        self.base_api_url = BASE_BINANCE_API_URL
+        self.base_margin_api_url = BASE_BINANCE_MARGIN_API_URL
 
     def fetch_candlestick_data(
         self,
@@ -222,7 +227,7 @@ class BinanceDownloader:
             full_params_str = (
                 f"{params_str}&startTime={start_timestamp}&endTime={end_timestamp}"
             )
-            url = f"https://api.binance.com/api/v3/klines?{full_params_str}&limit=1000"
+            url = f"{self.base_api_url}/api/v3/klines?{full_params_str}&limit=1000"
             response = requests.get(url)
             if response.status_code == 200:
                 json_data = response.json()
@@ -376,7 +381,7 @@ class BinanceDownloader:
         for i in range(len(monthly_timestamps) - 1):
             start_timestamp = monthly_timestamps[i] * 1000
             end_timestamp = monthly_timestamps[i + 1] * 1000
-            url = f"https://www.binance.com/bapi/margin/v1/public/margin/vip/spec/history-interest-rate?asset={asset_symbol}&vipLevel=0&size=90&startTime={start_timestamp}&endTime={end_timestamp}"
+            url = f"{self.base_margin_api_url}/v1/public/margin/vip/spec/history-interest-rate?asset={asset_symbol}&vipLevel=0&size=90&startTime={start_timestamp}&endTime={end_timestamp}"
             response = requests.get(url)
             if response.status_code == 200:
                 json_data = response.json()
@@ -610,7 +615,7 @@ class BinanceDownloader:
         """
 
         # https://binance-docs.github.io/apidocs/spot/en/#exchange-information
-        url = f"https://{self.api_server}/api/v3/exchangeInfo"
+        url = f"{self.base_api_url}/api/v3/exchangeInfo"
         resp = requests.get(url)
 
         # HTTP 451 Unavailable For Legal Reasons


### PR DESCRIPTION
Use env var to be able to override default Binance API urls