### PR TITLE
Avoid pd.MultiIndex on OHLCV data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Current
+
+- Update: Having pd.MultiIndex instead of per-pair pd.DateTimeIndex on candles slows down price access on backtesting considerably
+
 # 0.22.12
 
 - Update `fetch_all_spot_symbols` API call to Binance

--- a/tests/test_binance_data.py
+++ b/tests/test_binance_data.py
@@ -25,6 +25,10 @@ START_AT = datetime.datetime(2021, 1, 1)
 END_AT = datetime.datetime(2021, 1, 2)
 
 
+# Because of geoblocks, only run tests with we enable Binance Margin API specifically
+pytestmark = pytest.mark.skipif(not os.environ.get("BASE_BINANCE_MARGIN_API_URL"), reason="SEt BASE_BINANCE_MARGIN_API_URL to run these tests to a proxy server or https://www.binance.com/bapi/margin")
+
+
 @pytest.fixture(scope="module")
 def candle_downloader():
     return BinanceDownloader()

--- a/tradingstrategy/candle.py
+++ b/tradingstrategy/candle.py
@@ -568,8 +568,6 @@ class GroupedCandleUniverse(PairGroupedUniverse):
         except KeyError:
             pass
 
-        import ipdb ; ipdb.set_trace()
-
         #
         # No direct hit. Either sparse data or data not available before this.
         # Lookup just got complicated,

--- a/tradingstrategy/candle.py
+++ b/tradingstrategy/candle.py
@@ -26,6 +26,7 @@ from tradingstrategy.chain import ChainId
 from tradingstrategy.pair import DEXPair, HumanReadableTradingPairDescription
 from tradingstrategy.timebucket import TimeBucket
 from tradingstrategy.types import UNIXTimestamp, USDollarAmount, BlockNumber, PrimaryKey, NonChecksummedAddress
+from tradingstrategy.utils.df_index import flatten_dataframe_datetime_index
 from tradingstrategy.utils.groupeduniverse import PairGroupedUniverse
 from tradingstrategy.utils.time import ZERO_TIMEDELTA
 
@@ -361,7 +362,11 @@ class GroupedCandleUniverse(PairGroupedUniverse):
 
         if pair_id not in self.candles_cache:
             try:
-                self.candles_cache[pair_id] = self.get_samples_by_pair(pair_id)
+                candles = self.get_samples_by_pair(pair_id)
+                # Fix pd.MultiIndex issues that would slow down
+                # get_price_with_tolerance()
+                candles = flatten_dataframe_datetime_index(candles)
+                self.candles_cache[pair_id] = candles
             except KeyError:
                 return None
         
@@ -562,6 +567,8 @@ class GroupedCandleUniverse(PairGroupedUniverse):
             return sample, pd.Timedelta(seconds=0)
         except KeyError:
             pass
+
+        import ipdb ; ipdb.set_trace()
 
         #
         # No direct hit. Either sparse data or data not available before this.

--- a/tradingstrategy/client.py
+++ b/tradingstrategy/client.py
@@ -187,10 +187,11 @@ class Client(BaseClient):
         """
         path = self.transport.fetch_exchange_universe()
         with path.open("rt", encoding="utf-8") as inp:
+            data = inp.read()
             try:
-                return ExchangeUniverse.from_json(inp.read())
+                return ExchangeUniverse.from_json(data)
             except JSONDecodeError as e:
-                raise RuntimeError(f"Could not read JSON file {path}") from e
+                raise RuntimeError(f"Could not read ExchangeUniverse JSON file {path}\nData is {data}") from e
 
     @_retry_corrupted_parquet_fetch
     def fetch_all_candles(self, bucket: TimeBucket) -> pyarrow.Table:

--- a/tradingstrategy/transport/cache.py
+++ b/tradingstrategy/transport/cache.py
@@ -10,6 +10,7 @@ import platform
 import re
 from contextlib import contextmanager
 from importlib.metadata import version
+from json import JSONDecodeError
 from typing import Optional, Callable, Set, Union, Collection, Dict, Literal, Tuple
 import shutil
 import logging
@@ -357,7 +358,10 @@ class CachedHTTPTransport:
             # Quick fix to avoid getting hit by API key errors here.
             # TODO: Clean this up properly
             with open(path, "rt", encoding="utf-8") as inp:
-                data = json.load(inp)
+                try:
+                    data = json.load(inp)
+                except JSONDecodeError as e:
+                    raise RuntimeError(f"Invalid exchange universe data: {data}") from e
                 if "error" in data:
                     # API key error, do not save JSON data
                     os.remove(path)


### PR DESCRIPTION
- Having pd.MultiIndex instead of per-pair pd.DateTimeIndex on candles slows down price access on backtesting considerably
- Backtesting is fast after this patch