### PR TITLE
Add forward_fill_until to deal with gaps of rarely traded live pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Current
 
-- Add: `Client.fetch_top_pairs()`
-- 
+- Add: `Client.fetch_top_pairs()` - create a helper function to create always expanding trading universe for external signal providers
+- Add: `forward_fill(forward_fill_until)`. The default behavior is to forward fill gaps between first and last candle. However the last candle might not be updated if we load live sparse data and there has been no trades (no candles). Force the forward fill to go until a certain timestamp.
+
 # 0.24
 
 - Dependencies: Upgrade to Pandas 2.x. [NumPy 2.x is still incompatible](https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from).

--- a/tradingstrategy/candle.py
+++ b/tradingstrategy/candle.py
@@ -222,9 +222,11 @@ class Candle:
 
     @staticmethod
     def generate_synthetic_sample(
-            pair_id: int,
-            timestamp: pd.Timestamp,
-            price: float) -> dict:
+        pair_id: int,
+        timestamp: pd.Timestamp,
+        price: float,
+        volume: float | None = None,
+    ) -> dict:
         """Generate a candle dataframe.
 
         Used in testing when manually fiddled data is needed.
@@ -250,7 +252,7 @@ class Candle:
             "avg": 0,
             "start_block": 0,
             "end_block": 0,
-            "volume": 0,
+            "volume": 0 if volume is None else volume,
             "buy_volume": 0,
             "sell_volume": 0,
         }

--- a/tradingstrategy/utils/forward_fill.py
+++ b/tradingstrategy/utils/forward_fill.py
@@ -27,6 +27,7 @@ def forward_fill(
     freq: pd.DateOffset | str,
     columns: Collection[str] = ("open", "high", "low", "close", "volume", "timestamp"),
     drop_other_columns=True,
+    forward_fill_until: pd.Timestamp | None = None,
 ) -> pd.DataFrame:
     """Forward-fill OHLCV data for multiple trading pairs.
 
@@ -137,6 +138,14 @@ def forward_fill(
         The removed columns include ones like `high` and `low`, but also Trading Strategy specific
         columns like `start_block` and `end_block`. It's unlikely we are going to need
         forward-filled data in these columns.
+
+    :param forward_fill_until:
+        The timestamp which we know the data is valid for.
+
+        If there are price gaps at rarely traded pairs at the end of the (live) OHLCV series,
+        we will forward fill the data until this timestamp.
+
+        If not given forward fills until the last trade of the pair.
 
     :return:
         DataFrame where each timestamp has a value set for columns.

--- a/tradingstrategy/utils/forward_fill.py
+++ b/tradingstrategy/utils/forward_fill.py
@@ -220,6 +220,7 @@ def forward_fill(
     assert isinstance(single_or_multipair_data, (pd.DataFrame, DataFrameGroupBy))
     assert isinstance(freq, (pd.DateOffset, str)), f"Expected pd.DateOffset, got: {freq}"
 
+    original = single_or_multipair_data
     grouped = isinstance(single_or_multipair_data, DataFrameGroupBy)
 
     # https://www.statology.org/pandas-drop-all-columns-except/
@@ -263,14 +264,18 @@ def forward_fill(
                     # Fill open, high, low from the ffill'ed close.
                     single_or_multipair_data[column] = single_or_multipair_data[column].fillna(single_or_multipair_data["close"])
                 case "timestamp":
-                    assert not grouped, "cannot handle timestamp column in forward fill for multipair data"
+
+                    if grouped:
+                        check_columns = original.obj.columns
+                    else:
+                        check_columns = original.columns
 
                     if isinstance(single_or_multipair_data.index, pd.MultiIndex):
-                        if "timestamp" in single_or_multipair_data.obj.columns:
+                        if "timestamp" in check_columns:
                             # pair_id, timestamp index
                             single_or_multipair_data["timestamp"] = single_or_multipair_data.index.get_level_values(1)
                     elif isinstance(single_or_multipair_data.index, pd.DatetimeIndex):
-                        if "timestamp" in single_or_multipair_data.columns:
+                        if "timestamp" in check_columns:
                             # timestamp index
                             single_or_multipair_data["timestamp"] = single_or_multipair_data.index
                     else:

--- a/tradingstrategy/utils/wrangle.py
+++ b/tradingstrategy/utils/wrangle.py
@@ -264,6 +264,7 @@ def fix_dex_price_data(
     min_max_price: tuple | None = DEFAULT_MIN_MAX_RANGE,
     remove_candles_with_zero: bool = True,
     pair_id_column="pair_id",
+    forward_fill_until: datetime.datetime | None = None,
 ) -> pd.DataFrame:
     """Wrangle DEX price data for all known issues.
 
@@ -355,6 +356,14 @@ def fix_dex_price_data(
         Forward-filling data will delete any unknown columns,
         see :py:func:`tradingstrategy.utils.forward_fill.forward_fill` details.
 
+    :param forward_fill_until:
+        The timestamp which we know the data is valid for.
+
+        If there are price gaps at rarely traded pairs at the end of the (live) OHLCV series,
+        we will forward fill the data until this timestamp.
+
+        If not given forward fills until the last trade of the pair.
+
     :return:
         Fixed data frame.
 
@@ -395,6 +404,8 @@ def fix_dex_price_data(
 
         # Need to group here
         # TODO: Make this smarter, but how? Read index data in groupby instance?
+        assert "timestamp" in raw_df.columns, f"Got {raw_df.columns}"
+
         regrouped = raw_df.set_index("timestamp", drop=False).groupby(pair_id_column, group_keys=True)
 
         logger.info("Fixing prices having bad open/close values between timeframes: %s", fix_inbetween_threshold)


### PR DESCRIPTION
- Add: `forward_fill(forward_fill_until)`
- The default behavior is to forward fill gaps between first and last candle
- However the last candle might not be updated if we load live sparse data and there has been no trades (no candles)
- Force the forward fill to go until a certain timestamp