### PR TITLE
fix: share vault history filtering

### DIFF
--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from eth_defi.erc_4626.core import ERC4626Feature
-from tradingstrategy.alternative_data.vault import load_vault_database, convert_vaults_to_trading_pairs, load_single_vault, DEFAULT_VAULT_BUNDLE, load_multiple_vaults, load_vault_price_data, convert_vault_prices_to_candles
+from tradingstrategy.alternative_data.vault import load_vault_database, convert_vaults_to_trading_pairs, load_single_vault, DEFAULT_VAULT_BUNDLE, load_multiple_vaults, load_vault_price_data, convert_vault_prices_to_candles, filter_vault_price_history
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.chain import ChainId
 from tradingstrategy.exchange import ExchangeType, ExchangeUniverse
@@ -100,6 +100,52 @@ def test_load_multiple_vaults():
     exchanges, df = load_multiple_vaults([(ChainId.base, "0x45aa96f0b3188d47a1dafdbefce1db6b37f58216")])
     assert len(df) == 1
     assert len(exchanges) == 1
+
+
+def test_filter_vault_price_history_exact_match_and_date_window() -> None:
+    """Filter vault history by exact vault tuple and requested date window.
+
+    1. Build a small vault pair table and a mixed vault history DataFrame with overlapping addresses.
+    2. Run ``filter_vault_price_history()`` to normalise addresses and clip the time range.
+    3. Assert only the requested vault rows inside the requested window remain.
+    """
+    vault_pairs_df = pd.DataFrame(
+        [
+            {"chain_id": ChainId.base.value, "address": "0xabc"},
+            {"chain_id": ChainId.ethereum.value, "address": "0xdef"},
+        ]
+    )
+    vault_prices_df = pd.DataFrame(
+        [
+            {"chain": ChainId.base.value, "address": "0xABC", "timestamp": "2025-01-01", "share_price": 1.0},
+            {"chain": ChainId.base.value, "address": "0xabc", "timestamp": "2025-01-02", "share_price": 1.1},
+            {"chain": ChainId.ethereum.value, "address": "0xabc", "timestamp": "2025-01-02", "share_price": 2.0},
+            {"chain": ChainId.ethereum.value, "address": "0xdef", "timestamp": "2025-01-03", "share_price": 3.0},
+            {"chain": ChainId.ethereum.value, "address": "0xdef", "timestamp": "2025-01-05", "share_price": 4.0},
+        ]
+    )
+
+    # 1. Build input vault metadata and mixed history rows.
+    filtered_df = filter_vault_price_history(
+        vault_prices_df,
+        vault_pairs_df,
+        start_at=datetime.datetime(2025, 1, 2),
+        end_at=datetime.datetime(2025, 1, 4),
+    )
+
+    # 2. Filter the history with exact tuple matching and date clipping.
+    tuples = list(zip(filtered_df["chain"], filtered_df["address"], strict=False))
+
+    # 3. Assert we kept only the requested vault rows within the requested window.
+    assert tuples == [
+        (ChainId.base.value, "0xabc"),
+        (ChainId.ethereum.value, "0xdef"),
+    ]
+    assert filtered_df["timestamp"].tolist() == [
+        pd.Timestamp("2025-01-02"),
+        pd.Timestamp("2025-01-03"),
+    ]
+    assert pd.api.types.is_datetime64_any_dtype(filtered_df["timestamp"])
 
 
 def test_side_load_vault_price_data_hourly_resample():

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -10,6 +10,7 @@ To repackage the vault bundle:
 
 """
 
+import datetime
 from pathlib import Path
 from typing import Iterable
 
@@ -307,7 +308,7 @@ def load_vault_price_data(
     assert isinstance(pairs_df, pd.DataFrame)
 
     assert prices_path.exists(), f"Vault price file does not exist: {prices_path}"
-    vaults_to_match = {(row.chain_id, row.address) for idx, row in pairs_df.iterrows()}
+    vaults_to_match = {(int(row.chain_id), row.address.lower()) for _, row in pairs_df.iterrows()}
 
     assert len(vaults_to_match) < 3000, f"The vaults to load number looks too high: {len(vaults_to_match)}"
 
@@ -319,16 +320,64 @@ def load_vault_price_data(
     unique_chains = pa.array([int(c) for c, _ in vaults_to_match], type=pa.uint32())
     unique_addresses = pa.array(list({a for _, a in vaults_to_match}))
     table = table.filter(pc.is_in(table.column("chain"), unique_chains))
-    table = table.filter(pc.is_in(table.column("address"), unique_addresses))
+    table = table.filter(pc.is_in(pc.utf8_lower(table.column("address")), unique_addresses))
 
     # Convert only the filtered rows to pandas
     df = table.to_pandas()
+    return filter_vault_price_history(df, pairs_df)
 
-    # The Arrow filters are an over-approximation (chain IN set AND address IN set),
-    # so apply exact (chain, address) tuple matching on the small result
-    mask = pd.MultiIndex.from_arrays([df["chain"], df["address"]]).isin(vaults_to_match)
-    df = df[mask]
-    return df
+
+def filter_vault_price_history(
+    vault_prices_df: pd.DataFrame,
+    vault_pairs_df: pd.DataFrame,
+    start_at: datetime.datetime | None = None,
+    end_at: datetime.datetime | None = None,
+) -> pd.DataFrame:
+    """Filter vault history to the requested vaults and optional date window.
+
+    This helper centralises vault-history filtering so bundled parquet reads and
+    Trading Strategy website downloads expose the same caller-facing behaviour.
+
+    The returned DataFrame is normalised as follows:
+
+    - only exact ``(chain_id, address)`` tuples from ``vault_pairs_df`` remain
+    - ``address`` values are lowercased
+    - ``timestamp`` is materialised as a pandas datetime column
+    - optional ``start_at`` / ``end_at`` clipping is applied after tuple
+      filtering
+
+    The helper accepts vault history where ``timestamp`` is already a column or
+    where parquet round-tripping has placed it in the DataFrame index.
+    """
+    assert "chain" in vault_prices_df.columns, f"Got {vault_prices_df.columns}"
+    assert "address" in vault_prices_df.columns, f"Got {vault_prices_df.columns}"
+
+    if "timestamp" not in vault_prices_df.columns and vault_prices_df.index.name == "timestamp":
+        vault_prices_df = vault_prices_df.reset_index()
+
+    assert "timestamp" in vault_prices_df.columns, f"Got {vault_prices_df.columns}"
+
+    vaults_to_match = set(
+        zip(
+            vault_pairs_df["chain_id"].astype(int),
+            vault_pairs_df["address"].astype(str).str.lower(),
+            strict=False,
+        )
+    )
+    addresses = vault_prices_df["address"].astype(str).str.lower()
+    mask = pd.MultiIndex.from_arrays([vault_prices_df["chain"], addresses]).isin(vaults_to_match)
+    filtered_df = vault_prices_df.loc[mask].copy()
+
+    filtered_df["address"] = filtered_df["address"].astype(str).str.lower()
+    filtered_df["timestamp"] = pd.to_datetime(filtered_df["timestamp"])
+
+    if start_at is not None:
+        filtered_df = filtered_df.loc[filtered_df["timestamp"] >= pd.Timestamp(start_at)]
+
+    if end_at is not None:
+        filtered_df = filtered_df.loc[filtered_df["timestamp"] <= pd.Timestamp(end_at)]
+
+    return filtered_df
 
 
 
@@ -660,7 +709,4 @@ def load_vault_database_with_metadata(
             continue
 
     return VaultUniverse(vaults)
-
-
-
 


### PR DESCRIPTION
Why

We had the same vault history filtering rules split across two paths:

- bundled vault parquet reads in `tradingstrategy.alternative_data.vault`
- Trading Strategy website vault history filtering in `trade-executor`

That duplication makes it easier for exact `(chain_id, address)` matching, address normalisation, and date-window clipping to drift apart.

Lessons learnt

The actual filtering contract is small but important: match exact vault tuples, normalise addresses to lowercase, accept timestamp coming either from a column or parquet index, and clip the requested load window afterwards. Keeping that in one place gives us a safer base for the later Arrow-side loading optimisation work.

Summary

- add `filter_vault_price_history()` to `tradingstrategy.alternative_data.vault`
- reuse the helper from the bundled vault price loading path
- add a regression test covering exact tuple matching and date-window clipping
