### PR TITLE
fix: avoid redownloading unchanged vault price history parquet

### DIFF
--- a/tests/transport/test_cache.py
+++ b/tests/transport/test_cache.py
@@ -1,9 +1,14 @@
 import datetime as dt
+import os
 import time
+from email.utils import format_datetime
+from pathlib import Path
 from unittest.mock import Mock
 
+import orjson
 import pytest
 
+from tradingstrategy.transport.cache import CachedHTTPTransport
 from tradingstrategy.timebucket import TimeBucket
 
 
@@ -106,3 +111,97 @@ def test__generate_cache_name_end_time_minute_precision(
 
     assert name == expected_name
 
+
+def test_fetch_vault_price_history_reuses_expired_cache_when_head_matches(
+    transport: CachedHTTPTransport,
+    tmp_path: Path,
+) -> None:
+    """Test expired vault parquet cache reuse when remote HEAD metadata is unchanged.
+
+    1. Create an expired local parquet cache without any sidecar metadata yet.
+    2. Mock a remote HEAD response whose Last-Modified and Content-Length still match the local file.
+    3. Confirm the transport skips the download and refreshes the local cache timestamp.
+    """
+    download_root = tmp_path / "vault-downloads"
+    download_root.mkdir()
+    cached_path = download_root / "vault-price-history.parquet"
+    cached_path.write_bytes(b"abc")
+
+    expired_mtime = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)
+    os.utime(cached_path, (expired_mtime.timestamp(), expired_mtime.timestamp()))
+
+    remote_last_modified = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=3)
+    head_response = Mock()
+    head_response.headers = {
+        "Last-Modified": format_datetime(remote_last_modified),
+        "Content-Length": "3",
+    }
+    head_response.raise_for_status = Mock()
+    transport.requests.head = Mock(return_value=head_response)
+
+    # 1. Create an expired local parquet cache without any sidecar metadata yet.
+    original_mtime = cached_path.stat().st_mtime
+
+    # 2. Mock a remote HEAD response whose Last-Modified and Content-Length still match the local file.
+    result = transport.fetch_vault_price_history(
+        url="https://example.com/cleaned-vault-prices-1h.parquet",
+        download_root=download_root,
+    )
+
+    # 3. Confirm the transport skips the download and refreshes the local cache timestamp.
+    assert result == cached_path
+    transport.download_func.assert_not_called()
+    assert cached_path.stat().st_mtime > original_mtime
+    sidecar_path = cached_path.with_name("vault-price-history.parquet.metadata.json")
+    assert sidecar_path.exists()
+    assert orjson.loads(sidecar_path.read_bytes())["content_length"] == 3
+
+
+def test_fetch_vault_price_history_redownloads_when_head_metadata_changed(
+    transport: CachedHTTPTransport,
+    tmp_path: Path,
+) -> None:
+    """Test vault parquet redownload when remote HEAD metadata has changed.
+
+    1. Create an expired local parquet cache to force remote validation.
+    2. Mock a remote HEAD response whose Last-Modified and Content-Length indicate a newer file.
+    3. Confirm the transport performs a fresh download and stores the new sidecar metadata.
+    """
+    download_root = tmp_path / "vault-downloads"
+    download_root.mkdir()
+    cached_path = download_root / "vault-price-history.parquet"
+    cached_path.write_bytes(b"abc")
+
+    expired_mtime = dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=2)
+    os.utime(cached_path, (expired_mtime.timestamp(), expired_mtime.timestamp()))
+
+    remote_last_modified = dt.datetime.now(dt.timezone.utc)
+    head_response = Mock()
+    head_response.headers = {
+        "Last-Modified": format_datetime(remote_last_modified),
+        "Content-Length": "5",
+        "ETag": '"new-version"',
+    }
+    head_response.raise_for_status = Mock()
+    transport.requests.head = Mock(return_value=head_response)
+
+    def fake_download(session, path, url, params, timeout, human_desc) -> None:
+        Path(path).write_bytes(b"abcde")
+
+    transport.download_func.side_effect = fake_download
+
+    # 1. Create an expired local parquet cache to force remote validation.
+    result = transport.fetch_vault_price_history(
+        url="https://example.com/cleaned-vault-prices-1h.parquet",
+        download_root=download_root,
+    )
+
+    # 2. Mock a remote HEAD response whose Last-Modified and Content-Length indicate a newer file.
+    sidecar_path = cached_path.with_name("vault-price-history.parquet.metadata.json")
+
+    # 3. Confirm the transport performs a fresh download and stores the new sidecar metadata.
+    assert result == cached_path
+    transport.download_func.assert_called_once()
+    assert cached_path.read_bytes() == b"abcde"
+    assert sidecar_path.exists()
+    assert orjson.loads(sidecar_path.read_bytes())["etag"] == '"new-version"'

--- a/tradingstrategy/transport/cache.py
+++ b/tradingstrategy/transport/cache.py
@@ -11,6 +11,7 @@ import platform
 import re
 import shutil
 import time
+from email.utils import parsedate_to_datetime
 from http.client import IncompleteRead
 from importlib.metadata import PackageNotFoundError, version
 from json import JSONDecodeError
@@ -40,7 +41,7 @@ from tradingstrategy.transport.progress_enabled_download import \
     download_with_tqdm_progress_bar
 from tradingstrategy.types import AnyTimestamp, PrimaryKey, USDollarAmount
 from tradingstrategy.utils.logging_retry import LoggingRetry
-from tradingstrategy.utils.time import naive_utcnow
+from tradingstrategy.utils.time import naive_utcfromtimestamp, naive_utcnow
 from urllib3 import Retry
 
 logger = logging.getLogger(__name__)
@@ -586,6 +587,115 @@ class CachedHTTPTransport:
 
             return pathlib.Path(path)
 
+    def _get_sidecar_cache_metadata_path(self, path: str | Path) -> Path:
+        """Return the sidecar path used for remote HTTP cache metadata."""
+        parquet_path = Path(path)
+        return parquet_path.with_name(f"{parquet_path.name}.metadata.json")
+
+    def _load_sidecar_cache_metadata(self, path: str | Path) -> dict | None:
+        """Load stored remote HTTP cache metadata for a downloaded file."""
+        metadata_path = self._get_sidecar_cache_metadata_path(path)
+        if not metadata_path.exists():
+            return None
+
+        try:
+            return orjson.loads(metadata_path.read_bytes())
+        except Exception as exc:
+            logger.warning("Could not read sidecar cache metadata from %s: %s", metadata_path, exc)
+            return None
+
+    def _store_sidecar_cache_metadata(
+        self,
+        path: str | Path,
+        last_modified: datetime.datetime | None,
+        etag: str | None,
+        content_length: int | None,
+    ) -> None:
+        """Persist remote HTTP cache metadata for later HEAD comparisons."""
+        metadata_path = self._get_sidecar_cache_metadata_path(path)
+        payload = {
+            "last_modified": last_modified.isoformat() if last_modified is not None else None,
+            "etag": etag,
+            "content_length": content_length,
+            "stored_at": naive_utcnow().isoformat(),
+        }
+        metadata_path.write_bytes(orjson.dumps(payload))
+
+    def _parse_http_last_modified(self, header_value: str | None) -> datetime.datetime | None:
+        """Parse HTTP Last-Modified to a naive UTC datetime."""
+        if not header_value:
+            return None
+
+        parsed = parsedate_to_datetime(header_value)
+        if parsed.tzinfo is not None:
+            parsed = parsed.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        else:
+            parsed = parsed.replace(tzinfo=None)
+        return parsed
+
+    def _fetch_http_cache_metadata(self, url: str) -> tuple[datetime.datetime | None, str | None, int | None]:
+        """Fetch remote cache headers with a lightweight HEAD request."""
+        response = self.requests.head(
+            url,
+            allow_redirects=True,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+
+        last_modified = self._parse_http_last_modified(response.headers.get("Last-Modified"))
+        etag = response.headers.get("ETag")
+
+        content_length_header = response.headers.get("Content-Length")
+        if content_length_header is None:
+            content_length = None
+        else:
+            try:
+                content_length = int(content_length_header)
+            except ValueError:
+                logger.warning("Invalid Content-Length %r received from %s", content_length_header, url)
+                content_length = None
+
+        return last_modified, etag, content_length
+
+    def _is_matching_http_cache_metadata(
+        self,
+        path: str | Path,
+        remote_last_modified: datetime.datetime | None,
+        remote_etag: str | None,
+        remote_content_length: int | None,
+    ) -> bool:
+        """Decide whether the local file already matches the current remote asset."""
+        local_path = Path(path)
+        local_stat = local_path.stat()
+        local_mtime = naive_utcfromtimestamp(local_stat.st_mtime)
+        local_size = local_stat.st_size
+
+        if remote_content_length is not None and remote_content_length != local_size:
+            return False
+
+        local_metadata = self._load_sidecar_cache_metadata(path) or {}
+        local_etag = local_metadata.get("etag")
+        if remote_etag and local_etag == remote_etag:
+            return True
+
+        local_last_modified_raw = local_metadata.get("last_modified")
+        local_last_modified = None
+        if local_last_modified_raw:
+            try:
+                local_last_modified = datetime.datetime.fromisoformat(local_last_modified_raw)
+            except ValueError:
+                logger.warning("Invalid cached last_modified value %r in %s", local_last_modified_raw, path)
+
+        if remote_last_modified is not None:
+            if local_last_modified is not None and remote_last_modified == local_last_modified:
+                return True
+
+            # Fall back to the local file modification time when no sidecar metadata exists yet.
+            if remote_last_modified <= local_mtime:
+                return True
+
+        return False
+
     def fetch_vault_price_history(
         self,
         url: str | None = None,
@@ -623,10 +733,42 @@ class CachedHTTPTransport:
         with wait_other_writers(path):
 
             if os.path.exists(path):
-                mtime = datetime.datetime.fromtimestamp(pathlib.Path(path).stat().st_mtime)
-                cache_age = datetime.datetime.now() - mtime
+                mtime = naive_utcfromtimestamp(pathlib.Path(path).stat().st_mtime)
+                cache_age = naive_utcnow() - mtime
                 if cache_age < datetime.timedelta(hours=24):
                     return pathlib.Path(path)
+
+                try:
+                    remote_last_modified, remote_etag, remote_content_length = self._fetch_http_cache_metadata(url)
+                    if self._is_matching_http_cache_metadata(
+                        path=path,
+                        remote_last_modified=remote_last_modified,
+                        remote_etag=remote_etag,
+                        remote_content_length=remote_content_length,
+                    ):
+                        self._store_sidecar_cache_metadata(
+                            path=path,
+                            last_modified=remote_last_modified,
+                            etag=remote_etag,
+                            content_length=remote_content_length,
+                        )
+                        os.utime(path, None)
+                        logger.info("Reusing cached vault price history at %s because remote HEAD metadata is unchanged", path)
+                        return pathlib.Path(path)
+                except Exception as exc:
+                    logger.warning(
+                        "Could not validate cached vault price history at %s with a HEAD request to %s: %s. Falling back to a full download.",
+                        path,
+                        url,
+                        exc,
+                    )
+                    remote_last_modified = None
+                    remote_etag = None
+                    remote_content_length = None
+            else:
+                remote_last_modified = None
+                remote_etag = None
+                remote_content_length = None
 
             os.makedirs(self.get_abs_cache_path(download_root), exist_ok=True)
 
@@ -639,6 +781,14 @@ class CachedHTTPTransport:
                 self.timeout,
                 "Downloading cleaned vault price history dataset",
             )
+
+            if any(value is not None for value in (remote_last_modified, remote_etag, remote_content_length)):
+                self._store_sidecar_cache_metadata(
+                    path=path,
+                    last_modified=remote_last_modified,
+                    etag=remote_etag,
+                    content_length=remote_content_length,
+                )
 
             return pathlib.Path(path)
 


### PR DESCRIPTION
## Why

The cleaned vault price history parquet is around 150 MB, but the cache logic only looked at local file age. Once the file was older than 24 hours we downloaded it again even when the remote asset had not changed.

## Lessons learnt

A simple time-based cache is too blunt for large immutable-looking artefacts. A lightweight `HEAD` check gives us a much cheaper way to confirm freshness and lets us refresh the cache timestamp without moving the full payload again.

## Summary

- add a `HEAD` metadata check for `fetch_vault_price_history()` once the local cache is older than 24 hours
- persist `ETag`, `Last-Modified`, and `Content-Length` in a sidecar metadata JSON next to the cached parquet for future comparisons
- refresh the local cache timestamp when the remote file is unchanged, and only redownload when metadata changed or the `HEAD` check fails
- add transport tests covering both cache reuse and forced redownload paths
