### PR TITLE
feat: add VaultUniverse.limit_to_native_usdc()

### DIFF
--- a/tests/test_vault_metadata.py
+++ b/tests/test_vault_metadata.py
@@ -8,8 +8,28 @@ from unittest.mock import Mock
 import pandas as pd
 import pytest
 
+from tradingstrategy.chain import ChainId
 from tradingstrategy.client import Client
 from tradingstrategy.vault import Vault, VaultMetadata, VaultUniverse
+
+
+def _make_vault(chain_id, denomination_token_address, denomination_token_symbol="USDC", name="TestVault", vault_address=None):
+    """Build a minimal Vault for unit testing."""
+    addr = vault_address or f"0x{chain_id:040x}"
+    return Vault(
+        chain_id=ChainId(chain_id),
+        vault_address=addr,
+        denomination_token_address=denomination_token_address,
+        denomination_token_symbol=denomination_token_symbol,
+        denomination_token_decimals=6,
+        share_token_address=f"0xshare{addr[6:]}",
+        share_token_symbol="sVault",
+        share_token_decimals=6,
+        protocol_name="test",
+        protocol_slug="test",
+        name=name,
+        token_symbol="sVault",
+    )
 
 
 def test_vault_universe_with_metadata(
@@ -133,3 +153,29 @@ def test_fetch_vault_price_history(
 
     # 3. Confirm the parquet was cached on disk for later reuse.
     assert (download_root / "vault-price-history.parquet").exists()
+
+
+def test_limit_to_native_usdc():
+    """Verify address-aware native USDC filtering on VaultUniverse.
+
+    Vaults with symbol "USDC" but a non-native or missing denomination
+    address must be excluded when CCTP bridge generation is active.
+    """
+    from eth_defi.token import USDC_NATIVE_TOKEN
+
+    native_addr = USDC_NATIVE_TOKEN[1]  # Ethereum native USDC
+    vault_a = _make_vault(1, native_addr, name="NativeUSDC", vault_address="0xaaa0000000000000000000000000000000000001")
+    vault_b = _make_vault(1, "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", name="BridgedUSDC", vault_address="0xbbb0000000000000000000000000000000000002")
+    vault_c = _make_vault(1, None, name="MissingAddr", vault_address="0xccc0000000000000000000000000000000000003")
+
+    # All three together — only vault_a should survive
+    universe = VaultUniverse([vault_a, vault_b, vault_c])
+    filtered = universe.limit_to_native_usdc()
+    assert filtered.get_vault_count() == 1
+    remaining = list(filtered.iterate_vaults())
+    assert remaining[0].name == "NativeUSDC"
+
+    # Only non-native vaults — should raise
+    universe_bad = VaultUniverse([vault_b, vault_c])
+    with pytest.raises(AssertionError, match="No vaults with native USDC"):
+        universe_bad.limit_to_native_usdc()

--- a/tradingstrategy/vault.py
+++ b/tradingstrategy/vault.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime
+import logging
 from dataclasses import dataclass, field
 from typing import Iterable, TypeAlias, Any, Collection, TYPE_CHECKING
 
@@ -20,6 +21,8 @@ from tradingstrategy.chain import ChainId
 from tradingstrategy.exchange import ExchangeType
 from tradingstrategy.types import Percent, NonChecksummedAddress, TokenSymbol
 from tradingstrategy.types import SPECIAL_PAIR_ID_RANGE
+
+logger = logging.getLogger(__name__)
 
 
 def get_vault_page(vault_address: str) -> str:
@@ -838,6 +841,40 @@ class VaultUniverse:
             vault_list = (vault for vault in self.vaults.values() if vault.denomination_token_symbol in denomination_token_symbols)
 
         return VaultUniverse(vault_list)
+
+    def limit_to_native_usdc(self) -> "VaultUniverse":
+        """Keep only vaults denominated in the chain-native USDC token.
+
+        Uses the ``USDC_NATIVE_TOKEN`` address mapping so bridged USDC
+        variants (USDC.e, etc.) are excluded even when the symbol matches.
+
+        :raise AssertionError: If no vaults survive the filter.
+        """
+        from eth_defi.token import USDC_NATIVE_TOKEN
+
+        kept = []
+        excluded = []
+        for vault in self.vaults.values():
+            denomination_addr = (vault.denomination_token_address or "").lower()
+            native_addr = USDC_NATIVE_TOKEN.get(vault.chain_id)
+            if native_addr is not None and denomination_addr == native_addr.lower():
+                kept.append(vault)
+            else:
+                excluded.append(vault)
+
+        if excluded:
+            logger.info(
+                "CCTP native-USDC filter excluded %d vault(s): %s",
+                len(excluded),
+                ", ".join(f"{v.name} ({v.chain_id})" for v in excluded),
+            )
+
+        assert kept, (
+            f"No vaults with native USDC denomination found. "
+            f"All {len(excluded)} vault(s) were excluded."
+        )
+
+        return VaultUniverse(kept)
 
     def limit_to_chain(self, chain_id: ChainId | int) -> "VaultUniverse":
         """Drop all but single chain vault entries."""


### PR DESCRIPTION
## Summary

- Add `VaultUniverse.limit_to_native_usdc()` method that filters vaults by chain-native USDC contract address (from `USDC_NATIVE_TOKEN` mapping), not just token symbol
- Bridged USDC variants (USDC.e, etc.) that share the "USDC" symbol but have different addresses are correctly excluded
- Handles `None` denomination addresses safely (treated as excluded)
- Asserts non-empty result with a clear error message before hitting the generic `VaultUniverse.__init__` assertion
- Logs excluded vaults at INFO level for debugging
- Add unit test covering native/non-native/missing-address cases and empty-result assertion

Used by the xchain-master-vault strategy to auto-narrow vault denomination when `auto_generate_cctp_bridges=True`, replacing the manual notebook patch of `ALLOWED_VAULT_DENOMINATION_TOKENS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)