### PR TITLE
fix: Do not default missing vault token decimals to 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Fix vault metadata loader silently defaulting missing token decimals to 18: `load_vault_database_with_metadata()` now reads `denomination_decimals` / `share_token_decimals` from the JSON blob and leaves them `None` when absent instead of defaulting to 18 (which scaled raw amounts by 10\*\*12 for 6-decimal tokens like USDC) (2026-06-09)
 - Upgrade to Python 3.14 (2026-02-10)
 - Add Hypercore and Grvt chain support (2026-02-21)
 - Lazy-import vault_metrics/ffn and cache Binance exchange info for faster notebook startup (2026-03-12)

--- a/tests/test_vault_metadata.py
+++ b/tests/test_vault_metadata.py
@@ -179,3 +179,58 @@ def test_limit_to_native_usdc():
     universe_bad = VaultUniverse([vault_b, vault_c])
     with pytest.raises(AssertionError, match="No vaults with native USDC"):
         universe_bad.limit_to_native_usdc()
+
+
+def test_load_vault_metadata_decimals_no_default_18() -> None:
+    """Decimals are read from the JSON blob and missing ones stay None.
+
+    Regression: a missing ``denomination_decimals`` used to default to 18,
+    which silently scaled raw amounts by 10**12 for 6-decimal tokens like
+    USDC and reverted on-chain transfers (e.g. CCTP bridge depositForBurn).
+
+    1. Build one vault entry that carries denomination/share decimals.
+    2. Build one vault entry that omits the decimals keys.
+    3. Load both via ``load_vault_database_with_metadata()``.
+    4. Assert present decimals are read and missing ones are ``None`` — never
+       silently defaulted to 18.
+    """
+    from tradingstrategy.alternative_data.vault import load_vault_database_with_metadata
+
+    # 1. + 2. Build a JSON blob with one full and one decimals-less entry.
+    json_data = {
+        "vaults": [
+            {
+                "chain_id": ChainId.arbitrum.value,
+                "address": "0x1111111111111111111111111111111111111111",
+                "name": "USDC Vault",
+                "denomination": "USDC",
+                "denomination_token_address": "0xaf88d065e77c8cc2239327c5edb3a432268e5831",
+                "denomination_decimals": 6,
+                "share_token": "sUSDC",
+                "share_token_address": "0x2222222222222222222222222222222222222222",
+                "share_token_decimals": 18,
+            },
+            {
+                "chain_id": ChainId.base.value,
+                "address": "0x3333333333333333333333333333333333333333",
+                "name": "Legacy Vault",
+                "denomination": "USDC",
+                "denomination_token_address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+                "share_token": "sLEG",
+                # no decimals keys — must NOT default to 18
+            },
+        ]
+    }
+
+    # 3. Load the universe.
+    universe = load_vault_database_with_metadata(json_data)
+    vaults = {v.vault_address: v for v in universe.iterate_vaults()}
+
+    # 4. Present decimals are read; missing ones are None, never 18.
+    usdc_vault = vaults["0x1111111111111111111111111111111111111111"]
+    assert usdc_vault.denomination_token_decimals == 6
+    assert usdc_vault.share_token_decimals == 18
+
+    legacy_vault = vaults["0x3333333333333333333333333333333333333333"]
+    assert legacy_vault.denomination_token_decimals is None
+    assert legacy_vault.share_token_decimals is None

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -688,10 +688,16 @@ def load_vault_database_with_metadata(
                 token_symbol=vault_entry.get("share_token") or name,
                 denomination_token_address=(vault_entry.get("denomination_token_address") or "").lower(),
                 denomination_token_symbol=vault_entry.get("denomination") or "",
-                denomination_token_decimals=vault_entry.get("denomination_decimals", 18),
+                # Do NOT default missing decimals to a constant. A missing
+                # value used to default to 18, which silently scaled raw
+                # amounts by 10**12 for 6-decimal tokens like USDC and reverted
+                # on-chain transfers. Leave it None so consumers resolve the
+                # real decimals on-chain (the data source — top_vaults_by_chain
+                # .json — now carries denomination_decimals / share_token_decimals).
+                denomination_token_decimals=vault_entry.get("denomination_decimals"),
                 share_token_address=(vault_entry.get("share_token_address") or vault_address).lower(),
                 share_token_symbol=vault_entry.get("share_token") or name,
-                share_token_decimals=vault_entry.get("share_token_decimals", 18),
+                share_token_decimals=vault_entry.get("share_token_decimals"),
                 protocol_name=vault_entry.get("protocol") or "",
                 protocol_slug=vault_entry.get("protocol_slug") or "",
                 performance_fee=vault_entry.get("performance_fee"),

--- a/tradingstrategy/vault.py
+++ b/tradingstrategy/vault.py
@@ -531,7 +531,11 @@ class Vault:
     denomination_token_symbol: str
 
     #: 8 - 18
-    denomination_token_decimals: int
+    #:
+    #: ``None`` when the data source does not provide decimals. Consumers must
+    #: not assume a value (defaulting USDC to 18 scales raw amounts by 10**12);
+    #: resolve the real decimals on-chain instead.
+    denomination_token_decimals: int | None
 
     #: Share token address
     #:
@@ -542,7 +546,10 @@ class Vault:
     share_token_symbol: str
 
     #: 8 - 18
-    share_token_decimals: int
+    #:
+    #: ``None`` when the data source does not provide decimals (see
+    #: :py:attr:`denomination_token_decimals`).
+    share_token_decimals: int | None
 
     #: Protocol human readable name
     protocol_name: str


### PR DESCRIPTION
## Why

`load_vault_database_with_metadata()` read token decimals with a hardcoded fallback:

```python
denomination_token_decimals=vault_entry.get("denomination_decimals", 18),
share_token_decimals=vault_entry.get("share_token_decimals", 18),
```

The JSON blob it parses (`top_vaults_by_chain.json`) did not carry those keys at all (the producer dropped them), so **every** vault loaded via the metadata path silently got 18 decimals — correct for 18-decimal denominations, wrong for 6-decimal tokens like USDC/USDT.

Downstream this poisons `DEXPair.token0_decimals`, so `PandasPairUniverse.get_token(usdc).decimals` returns 18, and raw-amount math scales by `10**12`. It surfaced in `trade-executor` as a CCTP bridge `depositForBurn` burning `5000000000000000000` (5×10¹⁸) for 5 USDC and reverting with `ERC20: transfer amount exceeds balance`.

## Lessons learnt

- Never default a missing token-decimals value to a constant — `18` is silently wrong for stablecoins and breaks raw-amount conversions.
- `get_token(address)` is authoritative for *which* token, not for its decimals — it returns whatever the pipeline stored, so the stored value must be correct (or explicitly `None`).

## Summary

- **`alternative_data/vault.py`**: read `denomination_decimals` / `share_token_decimals` from the JSON and leave them `None` when absent, instead of defaulting to 18. Consumers must resolve the real decimals on-chain when `None`.
- **`vault.py`**: `Vault.denomination_token_decimals` / `share_token_decimals` typed `int | None`, with a docstring warning against assuming a value.
- **Tests**: `test_load_vault_metadata_decimals_no_default_18` asserts present decimals are read and missing ones stay `None` (fails on old code with `assert 18 is None`).
- **CHANGELOG.md**: entry added.

## Note

Producer half is `web3-ethereum-defi` PR #1088, which makes `top_vaults_by_chain.json` carry `denomination_decimals` / `share_token_decimals`. Once that ships and the dataset is regenerated, the `None` fallback only fires for genuinely-missing data. `trade-executor` has a defensive layer that pins native USDC to 6 and converts bridge amounts from on-chain decimals regardless.
