### PR TITLE
Speed up vault history parquet loading

### DIFF
--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from eth_defi.erc_4626.core import ERC4626Feature
-from tradingstrategy.alternative_data.vault import load_vault_database, convert_vaults_to_trading_pairs, load_single_vault, DEFAULT_VAULT_BUNDLE, load_multiple_vaults, load_vault_price_data, convert_vault_prices_to_candles, filter_vault_price_history
+from tradingstrategy.alternative_data.vault import load_vault_database, convert_vaults_to_trading_pairs, load_single_vault, DEFAULT_VAULT_BUNDLE, load_multiple_vaults, load_vault_price_data, convert_vault_prices_to_candles, filter_vault_price_history, read_vault_price_history_parquet
 from tradingstrategy.candle import GroupedCandleUniverse
 from tradingstrategy.chain import ChainId
 from tradingstrategy.exchange import ExchangeType, ExchangeUniverse
@@ -146,6 +146,123 @@ def test_filter_vault_price_history_exact_match_and_date_window() -> None:
         pd.Timestamp("2025-01-03"),
     ]
     assert pd.api.types.is_datetime64_any_dtype(filtered_df["timestamp"])
+
+
+def test_read_vault_price_history_parquet_filters_before_pandas_conversion(tmp_path: Path) -> None:
+    """Read only requested vault history rows from parquet.
+
+    1. Create a small parquet file with multiple chains, addresses and timestamps.
+    2. Read it through ``read_vault_price_history_parquet()`` with vault and date filters.
+    3. Assert only exact matching rows inside the requested date window remain.
+    """
+    parquet_path = tmp_path / "vault-price-history.parquet"
+    vault_pairs_df = pd.DataFrame(
+        [
+            {"chain_id": ChainId.base.value, "address": "0xabc"},
+        ]
+    )
+    vault_prices_df = pd.DataFrame(
+        [
+            {"chain": ChainId.base.value, "address": "0xABC", "timestamp": pd.Timestamp("2025-01-01"), "share_price": 1.0, "total_assets": 100.0},
+            {"chain": ChainId.base.value, "address": "0xabc", "timestamp": pd.Timestamp("2025-01-02"), "share_price": 1.1, "total_assets": 110.0},
+            {"chain": ChainId.ethereum.value, "address": "0xabc", "timestamp": pd.Timestamp("2025-01-02"), "share_price": 2.0, "total_assets": 200.0},
+            {"chain": ChainId.base.value, "address": "0xabc", "timestamp": pd.Timestamp("2025-01-04"), "share_price": 1.2, "total_assets": 120.0},
+        ]
+    )
+    vault_prices_df.to_parquet(parquet_path)
+
+    # 1. Create input parquet with mixed chains, addresses and timestamps.
+    filtered_df = read_vault_price_history_parquet(
+        parquet_path,
+        vault_pairs_df=vault_pairs_df,
+        start_at=datetime.datetime(2025, 1, 2),
+        end_at=datetime.datetime(2025, 1, 3),
+        columns=["share_price", "total_assets"],
+    )
+
+    # 2. Read the parquet through the filtered Arrow path.
+    assert filtered_df["chain"].tolist() == [ChainId.base.value]
+
+    # 3. Assert only exact matching rows inside the requested date window remain.
+    assert filtered_df["address"].tolist() == ["0xabc"]
+    assert filtered_df["timestamp"].tolist() == [pd.Timestamp("2025-01-02")]
+    assert filtered_df["share_price"].tolist() == [1.1]
+
+
+def test_read_vault_price_history_parquet_handles_unnamed_datetime_index(tmp_path: Path) -> None:
+    """Read vault history parquet where timestamp is stored as an unnamed index.
+
+    1. Create a parquet file whose datetime index is not named ``timestamp``.
+    2. Read it through ``read_vault_price_history_parquet()`` with a date filter.
+    3. Assert the returned frame exposes a normal ``timestamp`` column.
+    """
+    parquet_path = tmp_path / "vault-price-history.parquet"
+    vault_prices_df = pd.DataFrame(
+        {
+            "chain": [ChainId.base.value, ChainId.base.value],
+            "address": ["0xabc", "0xabc"],
+            "share_price": [1.0, 1.1],
+            "total_assets": [100.0, 110.0],
+        },
+        index=pd.DatetimeIndex(
+            [
+                pd.Timestamp("2025-01-01"),
+                pd.Timestamp("2025-01-02"),
+            ]
+        ),
+    )
+    vault_prices_df.to_parquet(parquet_path)
+
+    # 1. Create a parquet file whose datetime index is not named ``timestamp``.
+    filtered_df = read_vault_price_history_parquet(
+        parquet_path,
+        start_at=datetime.datetime(2025, 1, 2),
+        columns=["timestamp", "share_price"],
+    )
+
+    # 2. Read it through the filtered Arrow path.
+    assert "timestamp" in filtered_df.columns
+
+    # 3. Assert the returned frame exposes a normal ``timestamp`` column.
+    assert filtered_df["timestamp"].tolist() == [pd.Timestamp("2025-01-02")]
+    assert filtered_df["share_price"].tolist() == [1.1]
+
+
+def test_read_vault_price_history_parquet_normalises_timezone_aware_timestamps(tmp_path: Path) -> None:
+    """Read timezone-aware parquet timestamps using naive UTC filter bounds.
+
+    1. Create a parquet file with UTC-aware timestamp values.
+    2. Read it with naive UTC ``start_at`` and ``end_at`` filters.
+    3. Assert filtering succeeds and returns naive UTC timestamps.
+    """
+    parquet_path = tmp_path / "vault-price-history.parquet"
+    vault_pairs_df = pd.DataFrame(
+        [
+            {"chain_id": ChainId.base.value, "address": "0xabc"},
+        ]
+    )
+    vault_prices_df = pd.DataFrame(
+        [
+            {"chain": ChainId.base.value, "address": "0xabc", "timestamp": pd.Timestamp("2025-01-01T00:00:00Z"), "share_price": 1.0, "total_assets": 100.0},
+            {"chain": ChainId.base.value, "address": "0xabc", "timestamp": pd.Timestamp("2025-01-02T00:00:00Z"), "share_price": 1.1, "total_assets": 110.0},
+        ]
+    )
+    vault_prices_df.to_parquet(parquet_path)
+
+    # 1. Create a parquet file with UTC-aware timestamp values.
+    filtered_df = read_vault_price_history_parquet(
+        parquet_path,
+        vault_pairs_df=vault_pairs_df,
+        start_at=datetime.datetime(2025, 1, 2),
+        end_at=datetime.datetime(2025, 1, 2),
+    )
+
+    # 2. Read it with naive UTC ``start_at`` and ``end_at`` filters.
+    assert filtered_df["timestamp"].tolist() == [pd.Timestamp("2025-01-02")]
+
+    # 3. Assert filtering succeeds and returns naive UTC timestamps.
+    assert filtered_df["timestamp"].dt.tz is None
+    assert filtered_df["share_price"].tolist() == [1.1]
 
 
 def test_side_load_vault_price_data_hourly_resample():

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -15,6 +15,9 @@ from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.dataset as ds
 import zstandard
 
 from tradingstrategy.chain import ChainId
@@ -301,30 +304,113 @@ def load_vault_price_data(
         DataFrame with the columns as defined in the schema above.
 
     """
-    import pyarrow as pa
-    import pyarrow.compute as pc
-    import pyarrow.parquet as pq
-
     assert isinstance(pairs_df, pd.DataFrame)
 
     assert prices_path.exists(), f"Vault price file does not exist: {prices_path}"
-    vaults_to_match = {(int(row.chain_id), row.address.lower()) for _, row in pairs_df.iterrows()}
+    chain_values = pairs_df["chain_id"].astype(int)
+    address_values = pairs_df["address"].astype(str).str.lower()
+    vaults_to_match = set(zip(chain_values, address_values, strict=False))
 
     assert len(vaults_to_match) < 3000, f"The vaults to load number looks too high: {len(vaults_to_match)}"
 
-    # Read as Arrow table without pandas conversion
-    table = pq.read_table(str(prices_path))
-
-    # Filter in Arrow by unique chains and addresses (much faster than
-    # converting everything to pandas first)
-    unique_chains = pa.array([int(c) for c, _ in vaults_to_match], type=pa.uint32())
-    unique_addresses = pa.array(list({a for _, a in vaults_to_match}))
-    table = table.filter(pc.is_in(table.column("chain"), unique_chains))
-    table = table.filter(pc.is_in(pc.utf8_lower(table.column("address")), unique_addresses))
+    # Push the coarse chain/address predicate into the Parquet scanner so Arrow
+    # can skip row groups before materialising a table.
+    unique_chains = pa.array(sorted({int(c) for c, _ in vaults_to_match}), type=pa.uint32())
+    unique_addresses = pa.array(sorted({a for _, a in vaults_to_match}))
+    dataset = ds.dataset(str(prices_path), format="parquet")
+    table = dataset.to_table(
+        filter=(
+            pc.is_in(ds.field("chain"), value_set=unique_chains)
+            & pc.is_in(pc.utf8_lower(ds.field("address")), value_set=unique_addresses)
+        ),
+    )
 
     # Convert only the filtered rows to pandas
     df = table.to_pandas()
     return filter_vault_price_history(df, pairs_df)
+
+
+def read_vault_price_history_parquet(
+    prices_path: Path,
+    vault_pairs_df: pd.DataFrame | None = None,
+    start_at: datetime.datetime | None = None,
+    end_at: datetime.datetime | None = None,
+    columns: list[str] | None = None,
+) -> pd.DataFrame:
+    """Read cleaned vault price history parquet with optional Arrow pushdown.
+
+    The live vault history parquet contains millions of rows across all vaults.
+    Strategies usually need a small vault subset and a bounded time range, so
+    pushing the coarse predicate into Arrow avoids materialising the full file
+    as pandas before filtering.
+    """
+    assert prices_path.exists(), f"Vault price file does not exist: {prices_path}"
+
+    dataset = ds.dataset(str(prices_path), format="parquet")
+    schema_names = set(dataset.schema.names)
+    if "timestamp" in schema_names:
+        timestamp_column = "timestamp"
+    elif "__index_level_0__" in schema_names:
+        timestamp_column = "__index_level_0__"
+    else:
+        raise AssertionError(f"Vault price file does not contain a timestamp column: {dataset.schema.names}")
+
+    timestamp_type = dataset.schema.field(timestamp_column).type
+    assert pa.types.is_timestamp(timestamp_type), f"Vault price timestamp column must be timestamp typed, got {timestamp_type}"
+    expression = None
+
+    if vault_pairs_df is not None:
+        chain_values = vault_pairs_df["chain_id"].astype(int)
+        address_values = vault_pairs_df["address"].astype(str).str.lower()
+        unique_chains = pa.array(sorted(set(chain_values)), type=pa.uint32())
+        unique_addresses = pa.array(sorted(set(address_values)))
+        expression = (
+            pc.is_in(ds.field("chain"), value_set=unique_chains)
+            & pc.is_in(pc.utf8_lower(ds.field("address")), value_set=unique_addresses)
+        )
+
+    if start_at is not None:
+        start_filter = ds.field(timestamp_column) >= _make_timestamp_scalar(start_at, timestamp_type)
+        expression = start_filter if expression is None else expression & start_filter
+
+    if end_at is not None:
+        end_filter = ds.field(timestamp_column) <= _make_timestamp_scalar(end_at, timestamp_type)
+        expression = end_filter if expression is None else expression & end_filter
+
+    if columns is not None:
+        requested_columns = [timestamp_column if c == "timestamp" else c for c in columns]
+        required_columns = {timestamp_column}
+        if vault_pairs_df is not None:
+            required_columns.update({"chain", "address"})
+        columns = list(dict.fromkeys([*requested_columns, *required_columns]))
+
+    table = dataset.to_table(filter=expression, columns=columns)
+    df = table.to_pandas(ignore_metadata=True)
+    if timestamp_column != "timestamp" and timestamp_column in df.columns:
+        df = df.rename(columns={timestamp_column: "timestamp"})
+
+    if vault_pairs_df is not None:
+        return filter_vault_price_history(df, vault_pairs_df, start_at=start_at, end_at=end_at)
+
+    if "timestamp" in df.columns:
+        _normalise_timestamp_column(df)
+
+    return df
+
+
+def _make_timestamp_scalar(
+    value: datetime.datetime,
+    timestamp_type: pa.DataType,
+) -> pa.Scalar:
+    """Build an Arrow timestamp scalar matching the parquet timestamp field."""
+    timestamp = pd.Timestamp(value)
+    if pa.types.is_timestamp(timestamp_type):
+        if timestamp_type.tz is None and timestamp.tzinfo is not None:
+            timestamp = timestamp.tz_convert(None)
+        elif timestamp_type.tz is not None and timestamp.tzinfo is None:
+            timestamp = timestamp.tz_localize("UTC")
+
+    return pa.scalar(timestamp.to_pydatetime(), type=timestamp_type)
 
 
 def filter_vault_price_history(
@@ -369,7 +455,7 @@ def filter_vault_price_history(
     filtered_df = vault_prices_df.loc[mask].copy()
 
     filtered_df["address"] = filtered_df["address"].astype(str).str.lower()
-    filtered_df["timestamp"] = pd.to_datetime(filtered_df["timestamp"])
+    _normalise_timestamp_column(filtered_df)
 
     if start_at is not None:
         filtered_df = filtered_df.loc[filtered_df["timestamp"] >= pd.Timestamp(start_at)]
@@ -378,6 +464,15 @@ def filter_vault_price_history(
         filtered_df = filtered_df.loc[filtered_df["timestamp"] <= pd.Timestamp(end_at)]
 
     return filtered_df
+
+
+def _normalise_timestamp_column(df: pd.DataFrame) -> None:
+    """Normalise timestamp column to naive UTC pandas datetimes in-place."""
+    if not pd.api.types.is_datetime64_any_dtype(df["timestamp"]):
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+
+    if isinstance(df["timestamp"].dtype, pd.DatetimeTZDtype):
+        df["timestamp"] = df["timestamp"].dt.tz_convert(None)
 
 
 
@@ -715,4 +810,3 @@ def load_vault_database_with_metadata(
             continue
 
     return VaultUniverse(vaults)
-

--- a/tradingstrategy/client.py
+++ b/tradingstrategy/client.py
@@ -247,18 +247,18 @@ class Client(BaseClient):
         :return:
             VaultUniverse containing Vault instances with full VaultMetadata.
         """
-        import json
+        import orjson
         from tradingstrategy.vault import VaultUniverse
         from tradingstrategy.alternative_data.vault import load_vault_database_with_metadata
 
         path = self.transport.fetch_vault_universe(url=url, download_root=download_root)
-        with path.open("rt", encoding="utf-8") as inp:
-            data = inp.read()
-            try:
-                json_data = json.loads(data)
-                return load_vault_database_with_metadata(json_data)
-            except JSONDecodeError as e:
-                raise RuntimeError(f"Could not read VaultUniverse JSON file {path}\nData is {data}") from e
+        data = path.read_bytes()
+        try:
+            json_data = orjson.loads(data)
+            return load_vault_database_with_metadata(json_data)
+        except JSONDecodeError as e:
+            display_data = data.decode("utf-8", errors="replace")
+            raise RuntimeError(f"Could not read VaultUniverse JSON file {path}\nData is {display_data}") from e
 
     @staticmethod
     def _normalise_vault_price_history_frame(df: pd.DataFrame) -> pd.DataFrame:
@@ -318,7 +318,7 @@ class Client(BaseClient):
                     # shape variation.
                     df = df.rename(columns={first_column: "timestamp"})
 
-        if "timestamp" in df.columns:
+        if "timestamp" in df.columns and not pd.api.types.is_datetime64_any_dtype(df["timestamp"]):
             # Normalise dtype too. This means downstream date filtering and
             # comparisons can rely on pandas datetime semantics immediately,
             # instead of reparsing the column in each consumer.


### PR DESCRIPTION
## Why

Vault strategies usually need a small subset of vault price history from the cleaned parquet file, but the existing loaders materialised much more data before filtering. This makes strategy universe construction slower than necessary for vault-heavy strategies.

## Lessons learnt

The `xchain-master-vault.py` benchmark showed the main cost was reading the 173 MB remote vault history parquet into pandas and then filtering 7.25M rows down to roughly 27k relevant rows. Arrow dataset filtering can push the chain, address and timestamp predicates into the parquet scan and only convert the selected rows to pandas.

## Summary

- Add `read_vault_price_history_parquet()` with optional vault, date and column filters.
- Use Arrow dataset scanner filtering for bundled legacy vault price loading as well.
- Use `orjson` for vault universe metadata parsing and avoid redundant timestamp copies.
- Add a focused test for filtered parquet reads.
