### PR TITLE
Add vault display flags to vault metadata

### DIFF
--- a/tests/test_vault_metadata.py
+++ b/tests/test_vault_metadata.py
@@ -32,6 +32,17 @@ def _make_vault(chain_id, denomination_token_address, denomination_token_symbol=
     )
 
 
+def _make_vault_entry(address: str, name: str, **extra) -> dict:
+    """Build a minimal vault metadata JSON entry."""
+    entry = {
+        "chain_id": ChainId.ethereum.value,
+        "address": address,
+        "name": name,
+    }
+    entry.update(extra)
+    return entry
+
+
 def test_vault_universe_with_metadata(
     persistent_test_client: Client,
     tmp_path: Path,
@@ -234,3 +245,54 @@ def test_load_vault_metadata_decimals_no_default_18() -> None:
     legacy_vault = vaults["0x3333333333333333333333333333333333333333"]
     assert legacy_vault.denomination_token_decimals is None
     assert legacy_vault.share_token_decimals is None
+
+
+def test_load_vault_metadata_vault_display_flags() -> None:
+    """Generic vault display flags are loaded from the JSON data contract.
+
+    1. Build vault entries with top-level flags, ``other_data`` flags, an
+       explicit empty top-level override and no flags.
+    2. Load the entries via ``load_vault_database_with_metadata()``.
+    3. Assert each metadata object carries the expected display flag value.
+    """
+    from tradingstrategy.alternative_data.vault import load_vault_database_with_metadata
+
+    red_flags = [
+        {"severity": "red", "type": "bad_debt_unrealized", "source": "morpho"},
+    ]
+    yellow_flags = [
+        {"severity": "yellow", "type": "not_whitelisted", "source": "morpho"},
+    ]
+
+    # 1. Build vault entries covering all supported flag sources.
+    json_data = {
+        "vaults": [
+            _make_vault_entry(
+                "0x1111111111111111111111111111111111111111",
+                "Top-level flags",
+                vault_display_flags=red_flags,
+            ),
+            _make_vault_entry(
+                "0x2222222222222222222222222222222222222222",
+                "Other data flags",
+                other_data={"vault_display_flags": yellow_flags},
+            ),
+            _make_vault_entry(
+                "0x3333333333333333333333333333333333333333",
+                "Explicit no flags",
+                vault_display_flags=[],
+                other_data={"vault_display_flags": yellow_flags},
+            ),
+            _make_vault_entry("0x4444444444444444444444444444444444444444", "No flags"),
+        ]
+    }
+
+    # 2. Load the universe.
+    universe = load_vault_database_with_metadata(json_data)
+    vaults = {v.vault_address: v for v in universe.iterate_vaults()}
+
+    # 3. Top-level flags win, ``other_data`` fallback works and missing flags stay None.
+    assert vaults["0x1111111111111111111111111111111111111111"].metadata.vault_display_flags == red_flags
+    assert vaults["0x2222222222222222222222222222222222222222"].metadata.vault_display_flags == yellow_flags
+    assert vaults["0x3333333333333333333333333333333333333333"].metadata.vault_display_flags == []
+    assert vaults["0x4444444444444444444444444444444444444444"].metadata.vault_display_flags is None

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -663,6 +663,11 @@ def _parse_vault_metadata(entry: dict) -> VaultMetadata:
 
     # Parse features - may be list of strings or list of enums
     features = entry.get("features", [])
+    other_data = entry.get("other_data") or {}
+    if "vault_display_flags" in entry:
+        vault_display_flags = entry["vault_display_flags"]
+    else:
+        vault_display_flags = other_data.get("vault_display_flags")
 
     return VaultMetadata(
         vault_name=entry.get("name"),
@@ -717,6 +722,7 @@ def _parse_vault_metadata(entry: dict) -> VaultMetadata:
         link=entry.get("link"),
         trading_strategy_link=entry.get("trading_strategy_link"),
         flags=entry.get("flags"),
+        vault_display_flags=vault_display_flags,
         period_results=period_results,
     )
 

--- a/tradingstrategy/vault.py
+++ b/tradingstrategy/vault.py
@@ -399,6 +399,11 @@ class VaultMetadata:
     #: Set of warning or status flags for the vault.
     flags: list | None = None
 
+    #: Generic warning flags suitable for compact UI display.
+    #:
+    #: Each entry is expected to contain at least ``severity`` and ``type``.
+    vault_display_flags: list[dict] | None = None
+
     #: Block number of first price update.
     #:
     #: The blockchain block when first price data was recorded.


### PR DESCRIPTION
## Why

Vault consumers need a generic metadata field for compact warning display, without hard-coding protocol-specific Morpho keys in downstream applications.

## Lessons learnt

The metadata parser must preserve an explicit empty top-level `vault_display_flags` list, because it means the producer intentionally reports no display warnings and should not fall back to stale extension data.

## Summary

- Add optional `VaultMetadata.vault_display_flags`.
- Parse display flags from top-level JSON or the existing `other_data` extension block.
- Cover top-level, fallback, explicit empty and missing cases in metadata loading tests.