### PR TITLE
build: prune optional package data bundles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ version = "0.28"
 exclude = [
   # Don't include various blockchain icons in the release
   "tradingstrategy/chains/_data/icons",
-  "./tradingstrategy/chains/_data/iconsDownload",
+  "tradingstrategy/chains/_data/iconsDownload",
+  # Coingecko metadata is optional and too large for the default runtime package
+  "tradingstrategy/data_bundles/coingecko.json.zstd",
   "extras",
 ]
 


### PR DESCRIPTION
## Why

The default Python package should not ship optional CoinGecko metadata or chain icon assets when runtime code only needs chain JSON metadata. These bundled files increase downstream package and Docker payload size.

## Lessons learnt

The chain icon exclusions were already intended, but the iconsDownload path used a different form. Keeping these exclusions explicit in package metadata makes package builds smaller without changing chain lookup behaviour.

## Summary

- Exclude `tradingstrategy/data_bundles/coingecko.json.zstd` from the default package.
- Normalise the `chains/_data/iconsDownload` exclusion path.
- Keep `chains/_data/chains` packaged for `ChainId` metadata lookups.