### PR TITLE
feat: expose per-(vault, timestamp) deposit/redemption availability in vault price loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Add per-(vault, timestamp) deposit/redemption availability to vault price loading: `read_vault_price_history_parquet()` is now schema-tolerant for optional columns and `convert_vault_prices_to_vault_state()` exposes `deposits_open` / `redemption_open` / hard caps so backtests can model when a vault could be deposited into or redeemed from (2026-06-25)
 - Fix vault metadata loader silently defaulting missing token decimals to 18: `load_vault_database_with_metadata()` now reads `denomination_decimals` / `share_token_decimals` from the JSON blob and leaves them `None` when absent instead of defaulting to 18 (which scaled raw amounts by 10\*\*12 for 6-decimal tokens like USDC) (2026-06-09)
 - Upgrade to Python 3.14 (2026-02-10)
 - Add Hypercore and Grvt chain support (2026-02-21)

--- a/tests/test_vault_state.py
+++ b/tests/test_vault_state.py
@@ -1,0 +1,118 @@
+"""Tests for per-(vault, timestamp) deposit/redemption availability state.
+
+Covers :py:func:`convert_vault_prices_to_vault_state` and the schema-tolerant column
+handling in :py:func:`read_vault_price_history_parquet`. Uses synthetic data so the tests
+do not depend on the downloaded vault price bundle.
+"""
+import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from tradingstrategy.alternative_data.vault import (
+    convert_vault_prices_to_vault_state,
+    read_vault_price_history_parquet,
+    _normalise_bool_like,
+    VAULT_STATE_COLUMNS,
+)
+
+ADDR = "0x04c8e82bbd0a33d3179e767c262223f50e74f7d2"
+
+
+def _make_raw_hourly() -> pd.DataFrame:
+    """One vault, two days of hourly rows with an intra-day open->closed transition."""
+    rows = []
+    # Day 1: open at 00:00/06:00, then closed at 12:00/18:00 — last value within bucket is closed.
+    for hour, do, reason, max_dep in [
+        (0, "true", None, 1000.0),
+        (6, "true", None, 1000.0),
+        (12, "false", "Vault deposits disabled by leader", 0.0),
+        (18, "false", "Vault deposits disabled by leader", 0.0),
+    ]:
+        rows.append(_row("2026-03-05", hour, do, reason, max_dep))
+    # Day 2: open all day.
+    for hour in (0, 6, 12, 18):
+        rows.append(_row("2026-03-06", hour, "true", None, 1000.0))
+    return pd.DataFrame(rows)
+
+
+def _row(day: str, hour: int, deposits_open, reason, max_deposit) -> dict:
+    return {
+        "chain": 9999,
+        "address": ADDR,
+        "timestamp": pd.Timestamp(f"{day} {hour:02d}:00"),
+        "share_price": 1.0,
+        "total_assets": 1_000_000.0,
+        "deposits_open": deposits_open,
+        "redemption_open": pd.NA,
+        "deposit_closed_reason": reason,
+        "max_deposit": max_deposit,
+        "max_redeem": 500.0,
+    }
+
+
+def test_normalise_bool_like():
+    s = pd.Series(["true", "false", "TRUE", "False", None, "weird", pd.NA])
+    out = _normalise_bool_like(s)
+    assert out.dtype == "boolean"
+    assert list(out[:4]) == [True, False, True, False]
+    assert out[4] is pd.NA
+    assert out[5] is pd.NA
+    assert out[6] is pd.NA
+
+
+def test_convert_vault_state_daily_last_known_value():
+    """Daily resample takes the last value within each bucket (consistent with TVL candles)."""
+    state = convert_vault_prices_to_vault_state(_make_raw_hourly(), "1d")
+    assert state is not None
+    state = state.set_index("timestamp").sort_index()
+
+    # Two daily buckets.
+    assert len(state) == 2
+    assert state["deposits_open"].dtype == "boolean"
+
+    day1 = state.loc[pd.Timestamp("2026-03-05")]
+    day2 = state.loc[pd.Timestamp("2026-03-06")]
+
+    # Day 1: last value in the bucket is "closed".
+    assert day1["deposits_open"] == False  # noqa: E712
+    assert day1["deposit_closed_reason"] == "Vault deposits disabled by leader"
+    assert day1["max_deposit"] == 0.0
+
+    # Day 2: open.
+    assert day2["deposits_open"] == True  # noqa: E712
+    assert day2["max_deposit"] == 1000.0
+
+    # redemption_open is unknown everywhere in the source -> NA, never False.
+    assert state["redemption_open"].isna().all()
+
+    # pair_id is derived and stable per address.
+    assert state["pair_id"].nunique() == 1
+
+
+def test_convert_vault_state_returns_none_without_state_columns():
+    raw = _make_raw_hourly().drop(columns=VAULT_STATE_COLUMNS, errors="ignore")
+    assert convert_vault_prices_to_vault_state(raw, "1d") is None
+
+
+def test_read_parquet_tolerates_missing_state_columns(tmp_path):
+    """Requesting state columns from a file that lacks them must not raise."""
+    path = tmp_path / "no-state.parquet"
+    df = pd.DataFrame(
+        {
+            "chain": [9999, 9999],
+            "address": [ADDR, ADDR],
+            "timestamp": [pd.Timestamp("2026-03-05"), pd.Timestamp("2026-03-06")],
+            "share_price": [1.0, 1.01],
+            "total_assets": [1_000_000.0, 1_010_000.0],
+        }
+    )
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    pq.write_table(table, path)
+
+    pairs_df = pd.DataFrame([{"chain_id": 9999, "address": ADDR}])
+    requested = ["chain", "address", "timestamp", "share_price", "total_assets", *VAULT_STATE_COLUMNS]
+    out = read_vault_price_history_parquet(path, vault_pairs_df=pairs_df, columns=requested)
+
+    assert len(out) == 2
+    # State columns were silently dropped because the file does not carry them.
+    assert not any(c in out.columns for c in VAULT_STATE_COLUMNS)

--- a/tests/test_vault_state.py
+++ b/tests/test_vault_state.py
@@ -116,3 +116,33 @@ def test_read_parquet_tolerates_missing_state_columns(tmp_path):
     assert len(out) == 2
     # State columns were silently dropped because the file does not carry them.
     assert not any(c in out.columns for c in VAULT_STATE_COLUMNS)
+
+
+def test_convert_vault_state_takes_whole_last_row():
+    """The latest sample in a bucket wins as a whole row, including its nulls.
+
+    Regression: a per-column ``Resampler.last()`` would keep a stale close reason from earlier in
+    the bucket alongside a freshly re-opened ``deposits_open=True``.
+    """
+    rows = [
+        _row("2026-03-05", 0, "true", None, 1000.0),
+        _row("2026-03-05", 12, "false", "Vault deposits disabled by leader", 0.0),
+        _row("2026-03-05", 18, "true", None, 1000.0),  # reopened, reason cleared
+    ]
+    state = convert_vault_prices_to_vault_state(pd.DataFrame(rows), "1d").set_index("timestamp")
+    day = state.loc[pd.Timestamp("2026-03-05")]
+    assert day["deposits_open"] == True  # noqa: E712 — last row reopened
+    assert pd.isna(day["deposit_closed_reason"])  # stale noon reason must NOT carry over
+    assert day["max_deposit"] == 1000.0  # last row's cap, not the noon 0.0
+
+
+def test_convert_vault_state_latest_unknown_wins():
+    """A latest unknown (NA) sample is not overwritten by an earlier non-null value."""
+    rows = [
+        _row("2026-03-05", 0, "false", "Vault deposits disabled by leader", 0.0),
+        _row("2026-03-05", 18, None, None, float("nan")),  # latest sample is unknown
+    ]
+    state = convert_vault_prices_to_vault_state(pd.DataFrame(rows), "1d").set_index("timestamp")
+    day = state.loc[pd.Timestamp("2026-03-05")]
+    assert pd.isna(day["deposits_open"])  # latest unknown wins, not the earlier False
+    assert pd.isna(day["deposit_closed_reason"])

--- a/tests/test_vault_state.py
+++ b/tests/test_vault_state.py
@@ -7,6 +7,7 @@ do not depend on the downloaded vault price bundle.
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pytest
 
 from tradingstrategy.alternative_data.vault import (
     convert_vault_prices_to_vault_state,
@@ -146,3 +147,26 @@ def test_convert_vault_state_latest_unknown_wins():
     day = state.loc[pd.Timestamp("2026-03-05")]
     assert pd.isna(day["deposits_open"])  # latest unknown wins, not the earlier False
     assert pd.isna(day["deposit_closed_reason"])
+
+
+def test_read_parquet_errors_on_missing_non_state_column(tmp_path):
+    """A missing NON-state requested column still fails fast (not silently dropped)."""
+    path = tmp_path / "no-state.parquet"
+    df = pd.DataFrame(
+        {
+            "chain": [9999, 9999],
+            "address": [ADDR, ADDR],
+            "timestamp": [pd.Timestamp("2026-03-05"), pd.Timestamp("2026-03-06")],
+            "share_price": [1.0, 1.01],
+            "total_assets": [1_000_000.0, 1_010_000.0],
+        }
+    )
+    pq.write_table(pa.Table.from_pandas(df, preserve_index=False), path)
+    pairs_df = pd.DataFrame([{"chain_id": 9999, "address": ADDR}])
+    with pytest.raises(Exception):
+        # `share_priec` is a typo, not an optional state column -> must surface, not be dropped.
+        read_vault_price_history_parquet(
+            path,
+            vault_pairs_df=pairs_df,
+            columns=["chain", "address", "timestamp", "share_priec"],
+        )

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -395,10 +395,11 @@ def read_vault_price_history_parquet(
 
     if columns is not None:
         requested_columns = [timestamp_column if c == "timestamp" else c for c in columns]
-        # Silently drop requested columns that are absent from this parquet schema, so callers
-        # can opt in to optional columns (e.g. deposit/redemption state) without breaking on
-        # older files like the daily price bundle that do not carry them.
-        requested_columns = [c for c in requested_columns if c in schema_names]
+        # Drop only the *optional* vault-state columns when they are absent from this parquet
+        # schema, so callers can opt in to them without breaking on older files (e.g. the daily
+        # price bundle). Any other missing requested column is kept so the read still fails fast
+        # on a genuine schema mismatch (e.g. a misspelled `share_price`).
+        requested_columns = [c for c in requested_columns if c in schema_names or c not in VAULT_STATE_COLUMNS]
         required_columns = {timestamp_column}
         if vault_pairs_df is not None:
             required_columns.update({"chain", "address"})

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -51,6 +51,22 @@ DEFAULT_VAULT_BUNDLE = Path(__file__).parent / ".." / "data_bundles" / "vault-me
 #: Path to the example vault price data
 DEFAULT_VAULT_PRICE_BUNDLE = Path(__file__).parent / ".." / "data_bundles" / "vault-prices.parquet"
 
+#: Optional per-(vault, timestamp) availability columns in the cleaned vault price parquet.
+#:
+#: These describe whether a vault accepted new deposits / allowed redemptions at a given
+#: historical timestamp, plus any hard caps. They are only present in the cleaned hourly
+#: dataset (:py:data:`CLEANED_VAULT_PRICE_PARQUET_URL`) and only populated from the date the
+#: upstream scanner started recording them; older rows and the daily bundle lack them.
+#: Consumers must treat missing / unknown values as "allowed" rather than "closed".
+VAULT_STATE_COLUMNS = [
+    "deposits_open",
+    "redemption_open",
+    "deposit_closed_reason",
+    "redemption_closed_reason",
+    "max_deposit",
+    "max_redeem",
+]
+
 
 #: Cached loaded vault universe from our defaut bundle
 _cached_vault_universe: dict[Path, VaultUniverse] = {}
@@ -379,6 +395,10 @@ def read_vault_price_history_parquet(
 
     if columns is not None:
         requested_columns = [timestamp_column if c == "timestamp" else c for c in columns]
+        # Silently drop requested columns that are absent from this parquet schema, so callers
+        # can opt in to optional columns (e.g. deposit/redemption state) without breaking on
+        # older files like the daily price bundle that do not carry them.
+        requested_columns = [c for c in requested_columns if c in schema_names]
         required_columns = {timestamp_column}
         if vault_pairs_df is not None:
             required_columns.update({"chain", "address"})
@@ -583,6 +603,86 @@ def _resample(df: pd.DataFrame, frequency: str) -> pd.DataFrame:
     """Multipair resample helper."""
     df = resample_candles_multiple_pairs(df, frequency)
     return df
+
+
+#: Map our supported candle frequencies to pandas resample offsets.
+_VAULT_STATE_FREQUENCIES = {"1d": "1D", "1h": "1h"}
+
+
+def _normalise_bool_like(series: pd.Series) -> pd.Series:
+    """Normalise a ``true``/``false``/NA-ish column to pandas nullable boolean.
+
+    The cleaned vault parquet stores ``deposits_open`` / ``redemption_open`` as strings
+    (``"true"`` / ``"false"``) with NA for unknown. Anything that is not an explicit
+    ``true`` / ``false`` becomes :py:data:`pandas.NA` (unknown), which downstream consumers
+    must treat as "allowed".
+    """
+    lowered = series.astype("string").str.lower()
+    out = pd.Series(pd.NA, index=series.index, dtype="boolean")
+    out[lowered == "true"] = True
+    out[lowered == "false"] = False
+    return out
+
+
+def convert_vault_prices_to_vault_state(
+    raw_prices_df: pd.DataFrame,
+    frequency: str = "1d",
+) -> pd.DataFrame | None:
+    """Build a per-(pair, timestamp) vault availability state frame.
+
+    Companion to :py:func:`convert_vault_prices_to_candles`. Where that function turns share
+    price and TVL into OHLC candles, this extracts the deposit/redemption availability columns
+    (:py:data:`VAULT_STATE_COLUMNS`) so backtests can query, per timestamp, whether a vault
+    accepted deposits / allowed redemptions and skip impossible rebalances.
+
+    Resampling mirrors the TVL/price candle grid (same frequency, last-known value within each
+    bucket) so a state lookup at a timestamp is consistent with the TVL lookup at that same
+    timestamp. Empty buckets are left as NA; the consumer backward-fills at lookup time.
+    Boolean-like columns are normalised to nullable boolean via :py:func:`_normalise_bool_like`;
+    unknown/NA must be treated as "allowed".
+
+    :param raw_prices_df:
+        Vault price rows as returned by :py:func:`read_vault_price_history_parquet`, optionally
+        carrying some of :py:data:`VAULT_STATE_COLUMNS`. ``raw_prices_df`` may already have been
+        passed through :py:func:`convert_vault_prices_to_candles` (which only mutates OHLC
+        columns); the state columns are untouched.
+
+    :return:
+        Tidy DataFrame with columns ``pair_id``, ``address``, ``timestamp`` plus whichever of
+        :py:data:`VAULT_STATE_COLUMNS` are present, resampled to ``frequency``. Returns ``None``
+        if the source carries none of the state columns (e.g. the daily price bundle).
+    """
+    assert frequency in _VAULT_STATE_FREQUENCIES, f"Got {frequency}"
+
+    present = [c for c in VAULT_STATE_COLUMNS if c in raw_prices_df.columns]
+    if not present:
+        return None
+
+    assert "address" in raw_prices_df.columns, f"Got {raw_prices_df.columns}"
+    if "timestamp" not in raw_prices_df.columns and raw_prices_df.index.name == "timestamp":
+        raw_prices_df = raw_prices_df.reset_index()
+    assert "timestamp" in raw_prices_df.columns, f"Got {raw_prices_df.columns}"
+
+    df = raw_prices_df[["address", "timestamp", *present]].copy()
+    df["pair_id"] = df["address"].apply(_derive_pair_id_from_address)
+
+    for col in ("deposits_open", "redemption_open"):
+        if col in df.columns:
+            df[col] = _normalise_bool_like(df[col])
+
+    pandas_freq = _VAULT_STATE_FREQUENCIES[frequency]
+    df = df.set_index("timestamp").sort_index()
+
+    parts = []
+    for pair_id, group in df.groupby("pair_id", sort=False):
+        address = group["address"].iloc[0]
+        resampled = group[present].resample(pandas_freq).last()
+        resampled["pair_id"] = pair_id
+        resampled["address"] = address
+        parts.append(resampled)
+
+    # `timestamp` (the resample index) goes back to a column.
+    return pd.concat(parts).reset_index()
 
 
 def _parse_period_metrics(pm_dict: dict):

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -671,24 +671,16 @@ def convert_vault_prices_to_vault_state(
             df[col] = _normalise_bool_like(df[col])
 
     pandas_freq = _VAULT_STATE_FREQUENCIES[frequency]
-    df = df.set_index("timestamp").sort_index()
 
-    parts = []
-    for pair_id, group in df.groupby("pair_id", sort=False):
-        # Keep the last *row* in each resample bucket — all columns taken from the same sample,
-        # including nulls. `Resampler.last()` would instead take each column's last *non-null*
-        # value independently, which can pair a freshly re-opened `deposits_open=True` with a
-        # stale `deposit_closed_reason` from earlier in the same bucket. Floor each row to the
-        # bucket boundary (midnight for daily) so labels match the TVL/price candle grid.
-        bucketed = group[present].copy()
-        bucketed.index = group.index.floor(pandas_freq)
-        resampled = bucketed[~bucketed.index.duplicated(keep="last")].copy()
-        resampled["pair_id"] = pair_id
-        resampled["address"] = group["address"].iloc[0]
-        parts.append(resampled)
-
-    # The bucket label (index) goes back to a `timestamp` column.
-    return pd.concat(parts).reset_index()
+    # Floor each sample to its bucket (midnight for daily) and keep the last row per
+    # (pair, bucket): every column from the same latest sample, including nulls. A per-column
+    # `Resampler.last()` would take each column's last *non-null* value independently, which
+    # could pair a freshly re-opened `deposits_open=True` with a stale `deposit_closed_reason`
+    # from earlier in the bucket. Bucket labels match the TVL/price candle grid.
+    df = df.sort_values("timestamp")
+    df["timestamp"] = df["timestamp"].dt.floor(pandas_freq)
+    deduped = df.drop_duplicates(subset=["pair_id", "timestamp"], keep="last")
+    return deduped[["timestamp", "pair_id", "address", *present]].reset_index(drop=True)
 
 
 def _parse_period_metrics(pm_dict: dict):

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -636,11 +636,15 @@ def convert_vault_prices_to_vault_state(
     (:py:data:`VAULT_STATE_COLUMNS`) so backtests can query, per timestamp, whether a vault
     accepted deposits / allowed redemptions and skip impossible rebalances.
 
-    Resampling mirrors the TVL/price candle grid (same frequency, last-known value within each
-    bucket) so a state lookup at a timestamp is consistent with the TVL lookup at that same
-    timestamp. Empty buckets are left as NA; the consumer backward-fills at lookup time.
-    Boolean-like columns are normalised to nullable boolean via :py:func:`_normalise_bool_like`;
-    unknown/NA must be treated as "allowed".
+    Output is **sparse**: one row per populated bucket, floored to the bucket boundary (midnight
+    for daily, on the same grid as the TVL/price candles), taking the whole last sample in that
+    bucket. Gaps produce no row — the backtest consumer
+    (:py:class:`tradeexecutor.backtest.backtest_pricing.BacktestPricing`) backward-fills the
+    nearest sample at or before the decision timestamp within its data-delay tolerance, exactly
+    like the TVL lookup, so the sparse frame resolves correctly and a gap older than the
+    tolerance reads as unknown. (A dense NA-filled grid would instead resolve gap buckets to
+    "unknown" even when a recent sample exists.) Boolean-like columns are normalised to nullable
+    boolean via :py:func:`_normalise_bool_like`; unknown/NA must be treated as "allowed".
 
     :param raw_prices_df:
         Vault price rows as returned by :py:func:`read_vault_price_history_parquet`, optionally

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -675,13 +675,19 @@ def convert_vault_prices_to_vault_state(
 
     parts = []
     for pair_id, group in df.groupby("pair_id", sort=False):
-        address = group["address"].iloc[0]
-        resampled = group[present].resample(pandas_freq).last()
+        # Keep the last *row* in each resample bucket — all columns taken from the same sample,
+        # including nulls. `Resampler.last()` would instead take each column's last *non-null*
+        # value independently, which can pair a freshly re-opened `deposits_open=True` with a
+        # stale `deposit_closed_reason` from earlier in the same bucket. Floor each row to the
+        # bucket boundary (midnight for daily) so labels match the TVL/price candle grid.
+        bucketed = group[present].copy()
+        bucketed.index = group.index.floor(pandas_freq)
+        resampled = bucketed[~bucketed.index.duplicated(keep="last")].copy()
         resampled["pair_id"] = pair_id
-        resampled["address"] = address
+        resampled["address"] = group["address"].iloc[0]
         parts.append(resampled)
 
-    # `timestamp` (the resample index) goes back to a column.
+    # The bucket label (index) goes back to a `timestamp` column.
     return pd.concat(parts).reset_index()
 
 


### PR DESCRIPTION
## What

Adds the data plumbing so backtests can model **when a vault could be deposited into or redeemed from** at a given historical timestamp.

- `read_vault_price_history_parquet()` is now schema-tolerant: requested columns that are absent from the parquet schema are silently dropped, so callers can opt in to the optional availability columns without breaking on older files (e.g. the daily price bundle).
- New `VAULT_STATE_COLUMNS` and `convert_vault_prices_to_vault_state()`: extracts `deposits_open` / `redemption_open` / `deposit_closed_reason` / `max_deposit` / `max_redeem` into a tidy per-`(pair, timestamp)` frame, resampled to the strategy frequency with **last-known value** (consistent with the TVL/price candle grid) and boolean-like columns normalised to nullable booleans.

## Why

The cleaned hourly vault dataset carries deposit/redemption availability, but the loader only surfaced `share_price` + `total_assets`, so backtests implicitly assumed every vault was always open. This is the trading-strategy half; the trade-executor side consumes it in the backtest pricing model.

## Notes

- Unknown / missing values stay `NA` and consumers must treat them as "allowed" — this keeps existing backtests unchanged.
- Companion trade-executor PR threads this into the backtest pricing model (link to follow); land this one first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
