### PR TITLE
feat: accept synthetic non-EVM vault addresses in VaultUniverse lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Current
 
+- Accept synthetic non-EVM vault addresses in `VaultUniverse.limit_to_vaults()` and `get_by_vault_spec()`: the hardcoded `0x` prefix check now prefers the canonical `eth_defi.utils.is_good_multichain_address` (with a compat fallback for eth_defi releases predating it), so Lighter (`lighter-pool-`), GRVT (`vlt:`) and Hibachi (`hibachi-vault-`) pools can be limited to and looked up like EVM vaults (2026-07-22)
 - Add per-(vault, timestamp) deposit/redemption availability to vault price loading: `read_vault_price_history_parquet()` is now schema-tolerant for optional columns and `convert_vault_prices_to_vault_state()` exposes `deposits_open` / `redemption_open` / hard caps so backtests can model when a vault could be deposited into or redeemed from (2026-06-25)
 - Fix vault metadata loader silently defaulting missing token decimals to 18: `load_vault_database_with_metadata()` now reads `denomination_decimals` / `share_token_decimals` from the JSON blob and leaves them `None` when absent instead of defaulting to 18 (which scaled raw amounts by 10\*\*12 for 6-decimal tokens like USDC) (2026-06-09)
 - Upgrade to Python 3.14 (2026-02-10)

--- a/tradingstrategy/vault.py
+++ b/tradingstrategy/vault.py
@@ -12,6 +12,16 @@ except ImportError:
     # Spoof for soft imports
     ERC4626Feature: TypeAlias = str
 
+try:
+    from eth_defi.utils import is_good_multichain_address
+except ImportError:
+    # Compat shim: eth_defi releases predating `is_good_multichain_address`
+    # (and importing this module without eth_defi). Prefer the canonical
+    # eth_defi function whenever it is importable; this mirrors its prefix list.
+    def is_good_multichain_address(address: str) -> bool:
+        addr_lower = address.lower()
+        return addr_lower.startswith(("0x", "vlt:", "lighter-pool-", "hibachi-vault-"))
+
 if TYPE_CHECKING:
     from eth_defi.research.vault_metrics import PeriodMetrics
 else:
@@ -768,7 +778,6 @@ class VaultUniverse:
 
     def get_by_vault_spec(self, spec: tuple[ChainId | int, NonChecksummedAddress]) -> Vault | None:
         """Get vault by chain id and name."""
-
         chain_id = spec[0]
         address = spec[1]
 
@@ -777,7 +786,7 @@ class VaultUniverse:
 
         assert isinstance(chain_id, ChainId)
         assert type(address) == str
-        assert address.startswith("0x")
+        assert is_good_multichain_address(address), f"Unrecognised vault address: {address}"
         return self.vaults.get((chain_id, address.lower()))
 
     def get_vault_count(self) -> int:
@@ -805,7 +814,7 @@ class VaultUniverse:
 
             If not set, skip and do not care if some vaults are missing.
         """
-        assert all(type(v) in (tuple, list) and isinstance(v[0], (ChainId, int)) and v[1].startswith("0x") for v in vaults), f"Bad vault descriptors: {vaults}"
+        assert all(type(v) in (tuple, list) and isinstance(v[0], (ChainId, int)) and is_good_multichain_address(v[1]) for v in vaults), f"Bad vault descriptors: {vaults}"
         vaults = set(vaults)
 
         if check_all_vaults_found:    


### PR DESCRIPTION
## What

`VaultUniverse.limit_to_vaults()` and `get_by_vault_spec()` hardcoded a `startswith("0x")` assertion on vault addresses. Non-EVM venues use synthetic vault ids — Lighter (`lighter-pool-281474976539113`), GRVT (`vlt:...`), Hibachi (`hibachi-vault-...`) — so limiting a vault universe to Lighter pools raised `AssertionError: Bad vault descriptors`.

This replaces the prefix check with a small `_is_recognised_vault_address()` helper that delegates to `eth_defi.utils.is_good_multichain_address` when the optional `eth_defi` dependency is importable, and otherwise falls back to the same known-prefix list.

## Why

Needed to build and run a Lighter (chain 9998) vault-of-vaults backtest, where pools are addressed by synthetic ids. Part of a set of small changes across `web3-ethereum-defi`, `trading-strategy` and `trade-executor` that add Lighter support.

## Impact

Additive only: EVM `0x` addresses still pass, genuinely malformed addresses are still rejected. No behaviour change for existing EVM vault universes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)