### PR TITLE
fix: allow forcing HEAD revalidation of the vault price history cache

### DIFF
--- a/tests/transport/test_cache.py
+++ b/tests/transport/test_cache.py
@@ -157,6 +157,80 @@ def test_fetch_vault_price_history_reuses_expired_cache_when_head_matches(
     assert orjson.loads(sidecar_path.read_bytes())["content_length"] == 3
 
 
+def test_fetch_vault_price_history_revalidate_forces_head_inside_expiry_window(
+    transport: CachedHTTPTransport,
+    tmp_path: Path,
+) -> None:
+    """Test ``revalidate=True`` validates against the remote inside the local expiry window.
+
+    Inside the window the transport makes no HEAD request, so a parquet published
+    after the last check is not picked up. Live universe loads must not trust that,
+    but must also not re-download 200 MB when the remote is unchanged.
+
+    1. Create a cache file whose mtime is inside the window while the remote is newer.
+    2. Fetch without revalidation and confirm the cached file is served with no HEAD request.
+    3. Fetch with revalidation and confirm the HEAD runs and the newer remote is downloaded.
+    4. Fetch again with revalidation against an unchanged remote and confirm no download follows.
+    """
+    download_root = tmp_path / "vault-downloads"
+    download_root.mkdir()
+    cached_path = download_root / "vault-price-history.parquet"
+    sidecar_path = cached_path.with_name("vault-price-history.parquet.metadata.json")
+    url = "https://example.com/cleaned-vault-prices-1h.parquet"
+
+    def head_returning(headers: dict[str, str]) -> Mock:
+        response = Mock()
+        response.headers = headers
+        response.raise_for_status = Mock()
+        return Mock(return_value=response)
+
+    # 1. Create a cache file whose mtime is inside the window while the remote is newer.
+    cached_path.write_bytes(b"abc")
+    fresh_mtime = dt.datetime.now(dt.timezone.utc) - dt.timedelta(hours=2)
+    os.utime(cached_path, (fresh_mtime.timestamp(), fresh_mtime.timestamp()))
+    transport.requests.head = head_returning(
+        {
+            "Last-Modified": format_datetime(dt.datetime.now(dt.timezone.utc)),
+            "Content-Length": "5",
+            "ETag": '"new-version"',
+        }
+    )
+
+    # 2. Fetch without revalidation and confirm the cached file is served with no HEAD request.
+    assert transport.fetch_vault_price_history(url=url, download_root=download_root) == cached_path
+    transport.requests.head.assert_not_called()
+    transport.download_func.assert_not_called()
+    assert cached_path.read_bytes() == b"abc"
+
+    def fake_download(session, path, url, params, timeout, human_desc) -> None:
+        Path(path).write_bytes(b"abcde")
+
+    transport.download_func.side_effect = fake_download
+
+    # 3. Fetch with revalidation and confirm the HEAD runs and the newer remote is downloaded.
+    result = transport.fetch_vault_price_history(url=url, download_root=download_root, revalidate=True)
+    assert result == cached_path
+    transport.requests.head.assert_called_once()
+    transport.download_func.assert_called_once()
+    assert cached_path.read_bytes() == b"abcde"
+    assert orjson.loads(sidecar_path.read_bytes())["etag"] == '"new-version"'
+
+    # 4. Fetch again with revalidation against an unchanged remote and confirm no download follows.
+    transport.download_func.reset_mock()
+    transport.requests.head = head_returning(
+        {
+            "Last-Modified": format_datetime(dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=3)),
+            "Content-Length": "5",
+            "ETag": '"new-version"',
+        }
+    )
+    result = transport.fetch_vault_price_history(url=url, download_root=download_root, revalidate=True)
+    assert result == cached_path
+    transport.requests.head.assert_called_once()
+    transport.download_func.assert_not_called()
+    assert cached_path.read_bytes() == b"abcde"
+
+
 def test_fetch_vault_price_history_redownloads_when_head_metadata_changed(
     transport: CachedHTTPTransport,
     tmp_path: Path,

--- a/tradingstrategy/client.py
+++ b/tradingstrategy/client.py
@@ -332,6 +332,7 @@ class Client(BaseClient):
         self,
         url: str | None = None,
         download_root: str | Path | None = None,
+        revalidate: bool = False,
     ) -> pd.DataFrame:
         """Fetch cleaned vault share price history from the data server.
 
@@ -348,11 +349,16 @@ class Client(BaseClient):
             If not provided, uses
             :py:data:`tradingstrategy.alternative_data.vault.DEFAULT_VAULT_DOWNLOAD_ROOT`.
 
+        :param revalidate:
+            Always check the local cache against the remote file with a HEAD
+            request instead of trusting the 24-hour local expiry window.
+            See :py:meth:`tradingstrategy.transport.cache.CachedHTTPTransport.fetch_vault_price_history`.
+
         :return:
             Vault price history as a pandas DataFrame with an explicit
             ``timestamp`` column.
         """
-        path = self.transport.fetch_vault_price_history(url=url, download_root=download_root)
+        path = self.transport.fetch_vault_price_history(url=url, download_root=download_root, revalidate=revalidate)
         df = pd.read_parquet(path)
         return self._normalise_vault_price_history_frame(df)
 

--- a/tradingstrategy/transport/cache.py
+++ b/tradingstrategy/transport/cache.py
@@ -44,6 +44,14 @@ from tradingstrategy.utils.logging_retry import LoggingRetry
 from tradingstrategy.utils.time import naive_utcfromtimestamp, naive_utcnow
 from urllib3 import Retry
 
+
+#: How long a locally cached vault price history parquet is trusted without
+#: validating it against the remote file with a HEAD request.
+#:
+#: Measured from the last validation, not the last download -- see
+#: :py:meth:`CachedHTTPTransport.fetch_vault_price_history`.
+VAULT_PRICE_HISTORY_CACHE_PERIOD = datetime.timedelta(hours=24)
+
 logger = logging.getLogger(__name__)
 
 class OHLCVCandleType(enum.Enum):
@@ -700,11 +708,13 @@ class CachedHTTPTransport:
         self,
         url: str | None = None,
         download_root: str | Path | None = None,
+        revalidate: bool = False,
     ) -> pathlib.Path:
         """Load cached cleaned vault price history parquet.
 
         Downloads from the vault metadata parquet endpoint.
-        Uses 24-hour cache expiry.
+        Local copies are trusted for
+        :py:data:`VAULT_PRICE_HISTORY_CACHE_PERIOD` unless ``revalidate`` is set.
 
         :param url:
             URL to fetch the cleaned vault price history parquet from.
@@ -715,6 +725,21 @@ class CachedHTTPTransport:
             Override the root directory used for vault downloads.
             If not provided, uses
             :py:data:`tradingstrategy.alternative_data.vault.DEFAULT_VAULT_DOWNLOAD_ROOT`.
+
+        :param revalidate:
+            Always validate the local cache against the remote file with a HEAD
+            request, instead of trusting the local expiry window.
+
+            Inside the window no HEAD request is made at all, so a parquet
+            published after the last check is not picked up and nothing reports
+            that the local copy has fallen behind. The window is also measured
+            from the last validation rather than the last download, because a
+            HEAD check that finds the remote unchanged bumps the cached file's
+            mtime, so the clock restarts on every check.
+
+            Callers that must not run on data of unknown freshness pass
+            ``revalidate=True``. A matching remote still short-circuits the
+            download, so this costs one HEAD request, not a re-download.
 
         :return:
             Path to the cached parquet file.
@@ -733,18 +758,21 @@ class CachedHTTPTransport:
         with wait_other_writers(path):
 
             if os.path.exists(path):
-                mtime = naive_utcfromtimestamp(pathlib.Path(path).stat().st_mtime)
-                cache_age = naive_utcnow() - mtime
-                local_size = pathlib.Path(path).stat().st_size
-                if cache_age < datetime.timedelta(hours=24):
+                local_path = pathlib.Path(path)
+                local_stat = local_path.stat()
+                local_size = local_stat.st_size
+                cache_age = naive_utcnow() - naive_utcfromtimestamp(local_stat.st_mtime)
+                cache_expired = cache_age >= VAULT_PRICE_HISTORY_CACHE_PERIOD
+                if not cache_expired and not revalidate:
                     logger.info(
-                        "Vault price history cache hit: path=%s, cache_age=%s, local_size=%s bytes. Skipping download (< 24h threshold).",
-                        path, cache_age, local_size,
+                        "Vault price history cache hit: path=%s, cache_age=%s, local_size=%s bytes. Skipping download (age < %s).",
+                        path, cache_age, local_size, VAULT_PRICE_HISTORY_CACHE_PERIOD,
                     )
-                    return pathlib.Path(path)
+                    return local_path
 
                 logger.info(
-                    "Vault price history cache expired: path=%s, cache_age=%s, local_size=%s bytes. Performing HEAD check against %s.",
+                    "Vault price history cache %s: path=%s, cache_age=%s, local_size=%s bytes. Performing HEAD check against %s.",
+                    "expired" if cache_expired else "revalidation forced",
                     path, cache_age, local_size, url,
                 )
 
@@ -764,7 +792,7 @@ class CachedHTTPTransport:
                         )
                         os.utime(path, None)
                         logger.info("Reusing cached vault price history at %s because remote HEAD metadata is unchanged", path)
-                        return pathlib.Path(path)
+                        return local_path
                     else:
                         local_metadata = self._load_sidecar_cache_metadata(path) or {}
                         logger.info(


### PR DESCRIPTION
## Why

A live `trade-executor` failed to start with `DataTooOld` while holding a locally cached
`vault-price-history.parquet` whose newest rows were three days old. The remote file at
the time contained rows up to two hours before the crash, so the data itself was fine —
the executor was reading a stale local copy.

`fetch_vault_price_history()` trusts a cached parquet for 24 hours with no remote check
at all. Two properties of that window make it unsuitable for a live trading start-up:

- Inside the window **no HEAD request is made**, so a parquet published after the last
  check is not picked up, and nothing reports that the local copy has fallen behind.
- The window is measured from the **last validation, not the last download**. A HEAD
  check that finds the remote unchanged calls `os.utime(path, None)`, so the clock
  restarts on every check rather than on every download.

This does not by itself explain a three-day gap — a 24h window bounds staleness at
roughly 24h plus pipeline lag — so it is hardening rather than a confirmed root cause.
Pinning down the remaining gap needs the executor's own `Vault price history cache
hit/expired` and `Vault history freshness summary` log lines from the incident.

## Lessons learnt

- An mtime-keyed cache window silently changes meaning once anything touches mtime for
  bookkeeping. `os.utime()` here is sound on its own terms (it only runs after the local
  bytes were verified against the then-current remote), but it turns "age of the data"
  into "time since we last looked", which is not what the 24h literal reads as.
- A cache whose expiry is invisible in the happy path gives no signal when it goes wrong.
  The blind window produced no log line at all, so the staleness only surfaced three
  layers downstream as a `DataTooOld` crash on a 300-line table dump.
- Freshness policy belongs to the caller. The transport cannot know whether it is serving
  a backtest that wants the cheap path or a live executor that must not guess.

## Summary

- Add `revalidate: bool = False` to `CachedHTTPTransport.fetch_vault_price_history()`.
  When set, the local expiry window is skipped and the existing HEAD validation always
  runs. A matching remote still short-circuits the download, so a forced revalidation
  costs one HEAD request rather than a ~200 MB re-download.
- Thread the same flag through `Client.fetch_vault_price_history()`.
- Extract the window as the module constant `VAULT_PRICE_HISTORY_CACHE_PERIOD` and
  interpolate it into the cache-hit log line, so the message cannot drift from the code.
- Collapse a duplicated `stat()` call and reuse the resulting `pathlib.Path` for both
  early returns.
- Log line now distinguishes `cache expired` from `revalidation forced`.
- One new test covering the flag end to end: cached-and-fresh with a newer remote is
  served with no HEAD when the flag is off; with the flag on the HEAD runs and the newer
  remote is downloaded; a second forced revalidation against an unchanged remote makes
  the HEAD but no download.

The consumer side lands in tradingstrategy-ai/trade-executor, which passes
`revalidate=execution_context.mode.is_live_trading()` from `load_partial_data()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
