### PR TITLE
fix: support eth_defi vault chain ids

### DIFF
--- a/tests/test_binance_data.py
+++ b/tests/test_binance_data.py
@@ -29,20 +29,9 @@ END_AT = datetime.datetime(2021, 1, 2)
 pytestmark = pytest.mark.skipif(not os.environ.get("BASE_BINANCE_MARGIN_API_URL"), reason="Set BASE_BINANCE_MARGIN_API_URL to run these tests to a proxy server or https://www.binance.com/bapi/margin")
 
 
-@pytest.fixture(scope="module")
-def candle_downloader():
-    return BinanceDownloader()
-
-
-def test_read_fresh_candle_data(candle_downloader: BinanceDownloader):
-    """Test reading fresh candle data.
-
-    Will be mock data if run on Github, otherwise will be downloadeded from Binance API if local.
-
-    This is to check that the candle data is correct i.e. correct time bucket, no missing values, correct columns etc
-    """
-
-    correct_df = pd.DataFrame(
+def _make_correct_candle_df() -> pd.DataFrame:
+    """Create deterministic Binance candle data for cache tests."""
+    return pd.DataFrame(
         {
             "open": {
                 pd.Timestamp("2021-01-01"): 736.9,
@@ -70,6 +59,38 @@ def test_read_fresh_candle_data(candle_downloader: BinanceDownloader):
             },
         }
     )
+
+
+def _make_correct_lending_df() -> pd.DataFrame:
+    """Create deterministic Binance lending data for cache tests."""
+    return pd.DataFrame(
+        {
+            "lending_rates": {
+                pd.Timestamp("2021-01-01 00:00:00"): 9.125,
+                pd.Timestamp("2021-01-02 00:00:00"): 9.125,
+            },
+            "pair_id": {
+                pd.Timestamp("2021-01-01 00:00:00"): "ETH",
+                pd.Timestamp("2021-01-02 00:00:00"): "ETH",
+            },
+        }
+    )
+
+
+@pytest.fixture(scope="module")
+def candle_downloader():
+    return BinanceDownloader()
+
+
+def test_read_fresh_candle_data(candle_downloader: BinanceDownloader):
+    """Test reading fresh candle data.
+
+    Will be mock data if run on Github, otherwise will be downloadeded from Binance API if local.
+
+    This is to check that the candle data is correct i.e. correct time bucket, no missing values, correct columns etc
+    """
+
+    correct_df = _make_correct_candle_df()
 
     if os.environ.get("GITHUB_ACTIONS", None) == "true":
         with patch(
@@ -165,6 +186,12 @@ def test_read_cached_candle_data(candle_downloader: BinanceDownloader):
 
     Checks that the caching functionality works correctly.
     """
+    if os.environ.get("GITHUB_ACTIONS", None) == "true":
+        path = candle_downloader.get_parquet_path(
+            CANDLE_SYMBOL, TIME_BUCKET, START_AT, END_AT
+        )
+        _make_correct_candle_df().to_parquet(path)
+
     df = candle_downloader.get_data_parquet(
         CANDLE_SYMBOL, TIME_BUCKET, START_AT, END_AT
     )
@@ -183,18 +210,7 @@ def test_read_fresh_lending_data(candle_downloader: BinanceDownloader):
 
     This is to check that the lending data is correct i.e. correct time bucket, no missing values
     """
-    correct_df = pd.DataFrame(
-        {
-            "lending_rates": {
-                pd.Timestamp("2021-01-01 00:00:00"): 9.125,
-                pd.Timestamp("2021-01-02 00:00:00"): 9.125,
-            },
-            "pair_id": {
-                pd.Timestamp("2021-01-01 00:00:00"): "ETH",
-                pd.Timestamp("2021-01-02 00:00:00"): "ETH",
-            },
-        }
-    )
+    correct_df = _make_correct_lending_df()
 
     if os.environ.get("GITHUB_ACTIONS", None) == "true":
         with patch(
@@ -238,6 +254,12 @@ def test_read_cached_lending_data(candle_downloader: BinanceDownloader):
 
     Checks that the cache is working correctly
     """
+    if os.environ.get("GITHUB_ACTIONS", None) == "true":
+        path = candle_downloader.get_parquet_path(
+            LENDING_SYMBOL, LENDING_TIME_BUCKET, START_AT, END_AT, is_lending=True
+        )
+        _make_correct_lending_df().to_parquet(path)
+
     df = candle_downloader.get_data_parquet(
         LENDING_SYMBOL, LENDING_TIME_BUCKET, START_AT, END_AT, is_lending=True
     )

--- a/tests/test_caip.py
+++ b/tests/test_caip.py
@@ -56,3 +56,25 @@ def test_resolve_by_slug():
     c = ChainId.get_by_slug("arbitrum")
     assert c.value == 42161
 
+
+def test_new_vault_chain_ids_from_eth_defi() -> None:
+    """Support chain ids emitted by eth_defi vault metadata exports.
+
+    1. Resolve Tempo, Robinhood and ApeX by their raw chain ids.
+    2. Check their display names match the eth_defi chain metadata.
+    3. Check slug lookup works for URL and metadata consumers.
+    """
+    # 1. Resolve Tempo, Robinhood and ApeX by their raw chain ids.
+    tempo = ChainId(4217)
+    robinhood = ChainId(4663)
+    apex = ChainId(9995)
+
+    # 2. Check their display names match the eth_defi chain metadata.
+    assert tempo.get_name() == "Tempo"
+    assert robinhood.get_name() == "Robinhood"
+    assert apex.get_name() == "ApeX"
+
+    # 3. Check slug lookup works for URL and metadata consumers.
+    assert ChainId.get_by_slug("tempo") == tempo
+    assert ChainId.get_by_slug("robinhood") == robinhood
+    assert ChainId.get_by_slug("apex") == apex

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import pytest
+
+from tradingstrategy import reader
+from tradingstrategy.reader import BrokenData, read_parquet
+
+
+def test_read_parquet_wraps_os_error_with_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Parquet ``OSError`` keeps the file path for cache retry cleanup.
+
+    1. Mock PyArrow to raise the same error class seen in CI.
+    2. Read a temporary parquet path through ``read_parquet()``.
+    3. Assert the raised ``BrokenData`` carries the original file path.
+    """
+    parquet_path = tmp_path / "broken.parquet"
+
+    def mock_read_table(*args, **kwargs):
+        raise OSError("Column cannot have more than one dictionary.")
+
+    # 1. Mock PyArrow to raise the same error class seen in CI.
+    monkeypatch.setattr(reader.pq, "read_table", mock_read_table)
+
+    # 2. Read a temporary parquet path through ``read_parquet()``.
+    with pytest.raises(BrokenData) as exc_info:
+        read_parquet(parquet_path)
+
+    # 3. Assert the raised ``BrokenData`` carries the original file path.
+    assert exc_info.value.path == parquet_path

--- a/tests/test_vault_metadata.py
+++ b/tests/test_vault_metadata.py
@@ -9,6 +9,7 @@ import pandas as pd
 import pytest
 
 from tradingstrategy.chain import ChainId
+from tradingstrategy.alternative_data.vault import load_vault_database_with_metadata
 from tradingstrategy.client import Client
 from tradingstrategy.vault import Vault, VaultMetadata, VaultUniverse
 
@@ -327,3 +328,40 @@ def test_load_vault_metadata_vault_display_flags() -> None:
     assert vaults["0x2222222222222222222222222222222222222222"].metadata.vault_display_flags == yellow_flags
     assert vaults["0x3333333333333333333333333333333333333333"].metadata.vault_display_flags == []
     assert vaults["0x4444444444444444444444444444444444444444"].metadata.vault_display_flags is None
+
+
+def test_load_vault_metadata_supports_eth_defi_vault_chain_ids() -> None:
+    """Vault metadata accepts all chain ids emitted by eth_defi vault exports.
+
+    1. Build vault JSON entries for Tempo, Robinhood and ApeX.
+    2. Load the entries via ``load_vault_database_with_metadata()``.
+    3. Assert all entries survive parsing with typed ``ChainId`` values.
+    """
+    # 1. Build vault JSON entries for Tempo, Robinhood and ApeX.
+    json_data = {
+        "vaults": [
+            _make_vault_entry(
+                "0x1111111111111111111111111111111111111111",
+                "Tempo USDC",
+                chain_id=ChainId.tempo.value,
+            ),
+            _make_vault_entry(
+                "0x2222222222222222222222222222222222222222",
+                "Robinhood USDC",
+                chain_id=ChainId.robinhood.value,
+            ),
+            _make_vault_entry(
+                "0x3333333333333333333333333333333333333333",
+                "ApeX USDT",
+                chain_id=ChainId.apex.value,
+            ),
+        ],
+    }
+
+    # 2. Load the entries via ``load_vault_database_with_metadata()``.
+    universe = load_vault_database_with_metadata(json_data)
+    vaults = list(universe.iterate_vaults())
+
+    # 3. Assert all entries survive parsing with typed ``ChainId`` values.
+    assert len(vaults) == 3
+    assert {vault.chain_id for vault in vaults} == {ChainId.tempo, ChainId.robinhood, ChainId.apex}

--- a/tradingstrategy/chain.py
+++ b/tradingstrategy/chain.py
@@ -139,6 +139,12 @@ class ChainId(enum.IntEnum):
     #: Arbitrum One id
     arbitrum = 42161
 
+    #: Tempo
+    tempo = 4217
+
+    #: Robinhood Chain
+    robinhood = 4663
+
     #: Base
     base = 8453
 
@@ -269,6 +275,11 @@ class ChainId(enum.IntEnum):
     #:
     #: Does not have a real chain id, so we use a synthetic in-house id.
     hibachi = 9997
+
+    #: ApeX native.
+    #:
+    #: Does not have a real chain id, so we use a synthetic in-house id.
+    apex = 9995
 
     #: Grvt
     grvt = 325
@@ -414,6 +425,28 @@ _CHAIN_DATA_OVERRIDES = {
     },
 
     #
+    # Tempo
+    #
+    ChainId.tempo.value: {
+        "name": "Tempo",
+        "slug": "tempo",
+        "infoURL": "https://tempo.xyz",
+        "svg_icon": None,
+        "dataless": True,
+    },
+
+    #
+    # Robinhood Chain
+    #
+    ChainId.robinhood.value: {
+        "name": "Robinhood",
+        "slug": "robinhood",
+        "infoURL": "https://robinhood.com/us/en/chain/",
+        "svg_icon": None,
+        "dataless": True,
+    },
+
+    #
     # Base
     #
     ChainId.base.value: {
@@ -513,6 +546,17 @@ _CHAIN_DATA_OVERRIDES = {
     ChainId.hibachi.value: {
         "name": "Hibachi",
         "slug": "hibachi",
+        "svg_icon": None,
+        "dataless": True,
+    },
+
+    #
+    # ApeX
+    #
+    ChainId.apex.value: {
+        "name": "ApeX",
+        "slug": "apex",
+        "infoURL": "https://www.apex.exchange",
         "svg_icon": None,
         "dataless": True,
     },

--- a/tradingstrategy/reader.py
+++ b/tradingstrategy/reader.py
@@ -57,7 +57,7 @@ def read_parquet(path: Path, filters: Optional[List[Tuple]]=None, columns: Optio
     # https://arrow.apache.org/docs/python/parquet.html
     try:
         table = pq.read_table(f, filters=filters, columns=columns, use_threads=True, pre_buffer=False, memory_map=True)
-    except ArrowInvalid as e:
+    except (ArrowInvalid, OSError) as e:
         raise BrokenData(f"Could not read Parquet file: {f}\n"
                          f"Probably a corrupted download.\n"
                          f"See https://tradingstrategy.ai/docs/programming/troubleshooting.html#resetting-the-download-cache\n"


### PR DESCRIPTION
## Why

Vault metadata exported by eth_defi can now include Tempo (4217), Robinhood Chain (4663), and ApeX native vaults (9995). tradingstrategy.chain.ChainId did not recognise these ids, causing load_vault_database_with_metadata() to skip those vault entries and emit repeated warnings.

## Lessons learnt

The eth_defi chain metadata already carries these ids, but trading-strategy has its own ChainId enum and bundled chain-list snapshot. When the bundled chain-list data does not include a chain yet, trading-strategy needs a dataless override so enum metadata resolution still works.

CI also exposed two existing cache assumptions under xdist: cached Binance tests could run before their cache-seeding tests, and a damaged Parquet read could clear the whole shared persistent cache because the PyArrow OSError did not carry a file path through the retry wrapper.

## Summary

- Added ChainId.tempo, ChainId.robinhood, and ChainId.apex.
- Added dataless chain metadata overrides for Tempo, Robinhood, and ApeX.
- Added regression coverage for direct ChainId resolution, slug lookup, and vault metadata JSON parsing.

## Unrelated test fixes for CI green

- Wrapped PyArrow OSError as BrokenData in read_parquet() so retry cleanup removes only the damaged file instead of the whole shared cache directory.
- Made Binance cached-data tests seed their own deterministic mocked parquet files under GitHub Actions, removing their dependency on xdist execution order.
