### PR TITLE
feat: expose vault settlement estimates

### DIFF
--- a/tests/test_vault_metadata.py
+++ b/tests/test_vault_metadata.py
@@ -1,5 +1,6 @@
 """Integration tests for vault metadata loading."""
 
+import datetime
 import os
 
 from pathlib import Path
@@ -9,7 +10,7 @@ import pandas as pd
 import pytest
 
 from tradingstrategy.chain import ChainId
-from tradingstrategy.alternative_data.vault import load_vault_database_with_metadata
+from tradingstrategy.alternative_data.vault import _parse_vault_metadata, load_vault_database_with_metadata
 from tradingstrategy.client import Client
 from tradingstrategy.vault import Vault, VaultDepositPermission, VaultDepositStatus, VaultMetadata, VaultRedemptionStatus, VaultUniverse
 
@@ -42,6 +43,19 @@ def _make_vault_entry(address: str, name: str, **extra) -> dict:
     }
     entry.update(extra)
     return entry
+
+
+def test_vault_metadata_parses_estimated_settlement_seconds() -> None:
+    """Producer settlement seconds become a typed backtesting duration."""
+    metadata = _parse_vault_metadata(
+        _make_vault_entry(
+            "0x0000000000000000000000000000000000000001",
+            "Lagoon USDC",
+            estimated_settlement=86_400,
+        )
+    )
+
+    assert metadata.estimated_settlement == datetime.timedelta(days=1)
 
 
 def test_vault_universe_with_metadata(

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -71,6 +71,15 @@ VAULT_STATE_COLUMNS = [
     "max_redeem",
 ]
 
+#: Sparse historical settlement markers from the vault scanner.
+#:
+#: Unlike availability state, this timestamp is an event observation rather
+#: than a value that remains true until the next sample. Consumers must compare
+#: it against the request timestamp before treating it as settlement evidence.
+VAULT_SETTLEMENT_COLUMNS = [
+    "vault_settlement_at",
+]
+
 
 #: Cached loaded vault universe from our defaut bundle
 _cached_vault_universe: dict[Path, VaultUniverse] = {}
@@ -399,11 +408,12 @@ def read_vault_price_history_parquet(
 
     if columns is not None:
         requested_columns = [timestamp_column if c == "timestamp" else c for c in columns]
-        # Drop only the *optional* vault-state columns when they are absent from this parquet
+        # Drop only the optional vault-state / settlement columns when they are absent from this parquet
         # schema, so callers can opt in to them without breaking on older files (e.g. the daily
         # price bundle). Any other missing requested column is kept so the read still fails fast
         # on a genuine schema mismatch (e.g. a misspelled `share_price`).
-        requested_columns = [c for c in requested_columns if c in schema_names or c not in VAULT_STATE_COLUMNS]
+        optional_columns = set(VAULT_STATE_COLUMNS) | set(VAULT_SETTLEMENT_COLUMNS)
+        requested_columns = [c for c in requested_columns if c in schema_names or c not in optional_columns]
         required_columns = {timestamp_column}
         if vault_pairs_df is not None:
             required_columns.update({"chain", "address"})
@@ -663,7 +673,7 @@ def convert_vault_prices_to_vault_state(
     """
     assert frequency in _VAULT_STATE_FREQUENCIES, f"Got {frequency}"
 
-    present = [c for c in VAULT_STATE_COLUMNS if c in raw_prices_df.columns]
+    present = [c for c in [*VAULT_STATE_COLUMNS, *VAULT_SETTLEMENT_COLUMNS] if c in raw_prices_df.columns]
     if not present:
         return None
 

--- a/tradingstrategy/alternative_data/vault.py
+++ b/tradingstrategy/alternative_data/vault.py
@@ -763,6 +763,11 @@ def _parse_vault_metadata(entry: dict) -> VaultMetadata:
             return val.astimezone(datetime.timezone.utc).replace(tzinfo=None)
         return val
 
+    def _parse_timedelta_seconds(val) -> datetime.timedelta | None:
+        if not isinstance(val, (int, float)) or val <= 0:
+            return None
+        return datetime.timedelta(seconds=val)
+
     # Parse period_results if present
     period_results = None
     if entry.get("period_results"):
@@ -824,6 +829,7 @@ def _parse_vault_metadata(entry: dict) -> VaultMetadata:
         deposit_fee=entry.get("deposit_fee"),
         withdrawal_fee=entry.get("withdraw_fee"),
         lockup_days=entry.get("lockup"),
+        estimated_settlement=_parse_timedelta_seconds(entry.get("estimated_settlement")),
         risk_level=entry.get("risk"),
         notes=entry.get("notes"),
         deposit_status=deposit_status,

--- a/tradingstrategy/vault.py
+++ b/tradingstrategy/vault.py
@@ -305,6 +305,13 @@ class VaultMetadata:
     #: Estimated number of days funds are locked after deposit.
     lockup_days: float | None = None
 
+    #: Non-binding average vault settlement cycle.
+    #:
+    #: Parsed from the producer's ``estimated_settlement`` value, which is
+    #: serialised as seconds. Used for backtesting request settlement only;
+    #: it is not a contractual redemption deadline.
+    estimated_settlement: datetime.timedelta | None = None
+
     #: Risk classification name.
     #:
     #: Human-readable risk level (e.g. "low", "medium", "high", "blacklisted").


### PR DESCRIPTION
Expose producer settlement metadata and sparse historical settlement markers to backtests.

- Preserve `estimated_settlement` seconds as typed `VaultMetadata.estimated_settlement`.
- Preserve the optional `vault_settlement_at` scanner marker through vault-history reads and the resampled vault state frame.

Trade Executor uses this evidence to keep D2, Plutus, and Lagoon deposits queued until both the average-delay floor and a later real historical settlement event are satisfied.